### PR TITLE
Add workflow to create documentation artifacts

### DIFF
--- a/.github/workflows/builddocartifacts.yml
+++ b/.github/workflows/builddocartifacts.yml
@@ -1,0 +1,50 @@
+name: DocArtifacts
+
+on:
+  push:
+    branches-ignore:
+    - master
+  pull_request:
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build_docs:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version:  [3.8]
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v2
+        with:
+          path: main
+      - name: Check for documentation changes
+        run: |
+          cd main
+          echo "LAST_COMMIT=$(echo `git log -1 --pretty=%B`)" >> $GITHUB_ENV
+          echo "LAST_DOC_COMMIT=$(echo `git log -1 --pretty=%B docs`)" >> $GITHUB_ENV
+          if [ "$LAST_COMMIT" != "$LAST_DOC_COMMIT" ]; then
+            echo "No changes in documentation, skipping"
+            exit 0
+          fi
+      - name: Install needed packages
+        run: |
+          pip3 install wheel
+          pip3 install pytest
+          sudo apt update
+          sudo apt-get install python3-sphinx
+          cd main/docs
+          make html
+      - name: Checkout gh-pages
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          path: doc
+      - name: Upload documentation artifatcs
+        uses: actions/upload-artifact@v2
+        with:
+          name: DocumentationPages
+          path: main/docs/build/html/*


### PR DESCRIPTION
- enabled instead of docbuild (excludes push on master)
- allows to download an archive of the generated html
  (artifacts seem only to come as zip archives for GH actions)

This is a workaround to be able to preview docbuilds - have to download the zipped html. Still looking for a nicer way with GH pages.