### PR TITLE
Add automatic deploy workflow step triggered on pushing a tag

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -78,3 +78,53 @@ jobs:
       with:
         env_vars: OS
         name: codecov-pytest-order
+
+  deploy:
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+
+    runs-on: ubuntu-latest
+
+    needs: [linter, test]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: main
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - name: Install wheel and pytest
+      run: |
+        python -m pip install --upgrade pip
+        pip install wheel
+        pip install pytest
+    - name: Build package
+      run: |
+        cd main
+        python setup.py sdist bdist_wheel
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        packages_dir: main/dist/
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN_PYTEST_ORDER }}
+    - name: Create release docs
+      run: |
+        pip install sphinx
+        cd main/docs
+        make html
+    - name: Checkout gh-pages
+      uses: actions/checkout@v2
+      with:
+        ref: gh-pages
+        path: doc
+    - name: Copy and commit changes
+      run: |
+        cp -r main/docs/build/html/* doc/stable
+        cd doc
+        git config user.name "CI Build"
+        git config user.email "pytest_order@gmail.com"
+        git add stable/*
+        git commit -a -m "Release documentation"
+        git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Infrastructure
 - added performance tests to prevent performance degradation
+- added automated deploy workflow step triggered on creating a tag
 
 ## [Version 0.9.5](https://pypi.org/project/pytest-order/0.9.5/) (2021-02-16)
 Introduces hierarchical ordering option and fixes ordering of session-scoped


### PR DESCRIPTION
- publishs to PyPi, creates releases documentation and pushes it to gh-pages

Tested with TestPyPi, should also work with PyPi.