### PR TITLE
Fix handling of valid dependency loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 ### Fixes
 - fixed sorting of dependency markers that depend on an item with the same
   name in different modules
+- fixed handling of valid dependency loops (e.g. test1 is ordered after
+  test2, and test2 is ordered before test1)
 
 ### Infrastructure
 - added performance tests to prevent performance degradation

--- a/pytest_order/__init__.py
+++ b/pytest_order/__init__.py
@@ -84,5 +84,5 @@ class OrderingPlugin(object):
 
 
 def modify_items(session, config, items):
-    sorter = Sorter(config, items)
-    items[:] = sorter.sort_items()
+    item_sorter = Sorter(config, items)
+    items[:] = item_sorter.sort_items()

--- a/pytest_order/_version.py
+++ b/pytest_order/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0dev"
+__version__ = "1.0.0.dev0"

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -11,7 +11,8 @@ def test_version_exists():
 
 
 def test_version_valid():
-    assert re.match(r"[0-9]+\.[0-9]+(\.[0-9]+)?(dev)?$",
+    # check for PEP 440 conform version
+    assert re.match(r"\d+(\.\d)*((a|b|rc)\d+)?(\.post\d)?(\.dev\d)$",
                     pytest_order.__version__)
 
 

--- a/tests/test_relative_ordering.py
+++ b/tests/test_relative_ordering.py
@@ -154,7 +154,7 @@ class TestA:
     def test_c(self):
         pass
     """
-    write_test(os.path.join(fixture_path, "mod1_test.py",), tests_content1)
+    write_test(os.path.join(fixture_path, "mod1_test.py", ), tests_content1)
 
     tests_content2 = """
 import pytest
@@ -385,7 +385,7 @@ def test_dependency_in_class_before_unknown_test(item_names_for, capsys):
     assert warning in out
 
 
-def test_dependency_loop(item_names_for, capsys):
+def test_valid_dependency_loop(item_names_for, capsys):
     test_content = """
     import pytest
 
@@ -401,9 +401,23 @@ def test_dependency_loop(item_names_for, capsys):
     def test_3():
         pass
     """
+    assert item_names_for(test_content) == ["test_2", "test_3", "test_1"]
+
+
+def test_invalid_dependency_loop(item_names_for, capsys):
+    test_content = """
+    import pytest
+
+    @pytest.mark.order(after="test_3")
+    def test_1():
+        pass
+
+    @pytest.mark.order(1)
+    def test_2():
+        pass
+
+    @pytest.mark.order(after="test_1")
+    def test_3():
+        pass
+    """
     assert item_names_for(test_content) == ["test_2", "test_1", "test_3"]
-    out, err = capsys.readouterr()
-    warning = ("cannot execute test relative to others: "
-               "test_dependency_loop.test_1 test_dependency_loop.test_3 "
-               "- ignoring the marker")
-    assert warning in out


### PR DESCRIPTION
- use PEP 440 conform development version number

This is about dependencies like `test1` shall be executed after `test2`, and `test2` before `test1` - which is perfectly valid, but had been skipped before.