### PR TITLE
Use string lists instead of space separated strings for multiple relational markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,16 @@ version 1.0.0, which is planned for the near future.
 ### New features
 - added support for more than one relative marker for the same test
 
+### Infrastructure
+- added Python 3.10 to CI tests
+
 ## [Version 0.10.0](https://pypi.org/project/pytest-order/0.10.0/) (2021-03-18)
 Adds support for class-level relative markers and directory level scope.
 
 ### New features
 - added support for class level relative markers,
   see [#7](https://github.com/pytest-dev/pytest-order/issues/7)
-- added option `--order-scope-level` which allows to groups tests on the
+- added option `--order-scope-level` which allows grouping tests on the
   same directory level, 
   see [#8](https://github.com/pytest-dev/pytest-order/issues/8)
 
@@ -53,7 +56,8 @@ Patch release to make packaging easier.
 ### Infrastructure
 - use codecov instead of coveralls, that is failing
 - added pytest 6.2 to CI tests
-- added tests, examples and documentation to source package
+- added tests, examples and documentation to source package,
+  see [#5](https://github.com/pytest-dev/pytest-order/issues/5)
 
 ## [Version 0.9.3](https://pypi.org/project/pytest-order/0.9.3/) (2021-01-14)
 Bugfix release.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -392,8 +392,8 @@ modules, this could be expressed like:
  def test_b():
      assert True
 
-If an unknown test is referenced, a warning is issued and the test in
-question is ordered behind all other tests.
+If an unknown test is referenced, a warning is issued and the execution
+order of the test in is not changed.
 
 Markers on class level
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -461,13 +461,13 @@ Several relationships for the same marker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If you need to order a certain test relative to more than one other test, you
 can add more than one test name to the ``before`` or ``after`` marker
-attributes, separated by spaces:
+attributes by using a list of test names:
 
 .. code:: python
 
  import pytest
 
- @pytest.mark.order(after="test_second other_module.test_other")
+ @pytest.mark.order(after=["test_second", "other_module.test_other"])
  def test_first():
      assert True
 
@@ -584,9 +584,9 @@ Consider the following directory structure:
       test_a.py
       test_b.py
     feature2
-       __init__.py
-       test_a.py
-       test_b.py
+      __init__.py
+      test_a.py
+      test_b.py
 
 with the test contents:
 
@@ -677,7 +677,7 @@ the first two directory levels:
     order_scope_level/feature2/test_a.py::test_four PASSED
 
 Note that using a level of 0 or 1 would cause the same result as session
-scope, and any level greater than 2 would emulate module scope.
+scope in this example, and any level greater than 2 would emulate module scope.
 
 ``--order-group-scope``
 -----------------------

--- a/pytest_order/sorter.py
+++ b/pytest_order/sorter.py
@@ -241,14 +241,18 @@ class Sorter:
 
     def handle_relative_marks(self, item, mark):
         has_relative_marks = False
-        before_marks = mark.kwargs.get("before", "").split()
+        before_marks = mark.kwargs.get("before", [])
+        if before_marks and not isinstance(before_marks, list):
+            before_marks = [before_marks]
         for before_mark in before_marks:
             if self.handle_before_or_after_mark(
                     item, mark, before_mark, is_after=False):
                 has_relative_marks = True
             else:
                 self.warn_about_unknown_test(before_mark)
-        after_marks = mark.kwargs.get("after", "").split()
+        after_marks = mark.kwargs.get("after", [])
+        if after_marks and not isinstance(after_marks, list):
+            after_marks = [after_marks]
         for after_mark in after_marks:
             if self.handle_before_or_after_mark(
                     item, mark, after_mark, is_after=True):

--- a/tests/test_relative_ordering.py
+++ b/tests/test_relative_ordering.py
@@ -330,7 +330,7 @@ def test_multiple_markers_in_same_test(item_names_for):
     test_content = """
     import pytest
 
-    @pytest.mark.order(after="test_3 test_4 test_5")
+    @pytest.mark.order(after=["test_3", "test_4", "test_5"])
     def test_1():
         pass
 
@@ -340,7 +340,7 @@ def test_multiple_markers_in_same_test(item_names_for):
     def test_3():
         pass
 
-    @pytest.mark.order(before="test_3   test_2")
+    @pytest.mark.order(before=["test_3", "test_2"])
     def test_4():
         pass
 


### PR DESCRIPTION
- conforms to pytest-dependency, and is better readable and intuitive
- see #24