### PR TITLE
The relative warning now specifies which test can't be sorted

### DIFF
--- a/pytest_order/sorter.py
+++ b/pytest_order/sorter.py
@@ -177,8 +177,8 @@ class Sorter:
             is_after: bool) -> bool:
         def is_class_mark() -> bool:
             return (
-                    item.item.cls and
-                    item.item.parent.get_closest_marker("order") == mark
+                item.item.cls and
+                item.item.parent.get_closest_marker("order") == mark
             )
 
         def is_mark_for_class() -> bool:
@@ -219,7 +219,7 @@ class Sorter:
                     item, mark, before_mark, is_after=False):
                 has_relative_marks = True
             else:
-                self.warn_about_unknown_test(before_mark)
+                self.warn_about_unknown_test(item, before_mark)
         after_marks = mark.kwargs.get("after", ())
         if after_marks and not isinstance(after_marks, (list, tuple)):
             after_marks = (after_marks,)
@@ -228,13 +228,13 @@ class Sorter:
                     item, mark, after_mark, is_after=True):
                 has_relative_marks = True
             else:
-                self.warn_about_unknown_test(after_mark)
+                self.warn_about_unknown_test(item, after_mark)
         return has_relative_marks
 
     @staticmethod
-    def warn_about_unknown_test(rel_mark: str) -> None:
-        sys.stdout.write("\nWARNING: cannot execute test relative to others:"
-                         " {} - ignoring the marker.".format(rel_mark))
+    def warn_about_unknown_test(item: Item, rel_mark: str) -> None:
+        sys.stdout.write("\nWARNING: cannot execute '{}' relative to others: "
+                         "'{}' - ignoring the marker.".format(item.item.name, rel_mark))
 
     def collect_markers(self) -> None:
         aliases = {}


### PR DESCRIPTION
This changes the warning emitted for messed up relative order markers, so that they specify exactly which test got the ignored marker.

Previous output:
```
WARNING: cannot execute test relative to others: test.py::test_doesnt_exist - ignoring the marker.
```

This PR output:
```
WARNING: cannot execute 'test_with_messed_up_marker' relative to others: 'test.py::test_doesnt_exist' - ignoring the marker.
```

Should help debugging the situation by pointing at the test with the messed up marker, instead of "just saying" that one failed.

Side note: While testing this, I noticed that no warning is emitted for a messed up marker in some cases (at least with my codebase). I'm not sure why this happens, but if needed, I can try narrowing it down, and opening an issue if I'd find a minimal repro case. The current tests don't appear to encompass these warnings right now.

Side-side note: The overall code appears to have inconsistent formatting and multiple minor typing errors. I can make a PR that will help either (or both) of those two "problems", with your permission. I'm using [Black formatting style](https://black.readthedocs.io/en/stable/the_black_code_style.html), and [MyPy](https://github.com/python/mypy) for type checking.