### PR TITLE
Black code formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,9 @@
     "restructuredtext.confPath": "${workspaceFolder}\\docs\\source",
     "python.formatting.blackArgs": [
         "--line-length",
-        "80",
+        "79",
         "--skip-string-normalization"
     ],
     "python.formatting.provider": "black",
-    "editor.rulers": [80, 88]
+    "editor.rulers": [79, 87]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "restructuredtext.confPath": "${workspaceFolder}\\docs\\source",
+    "python.formatting.blackArgs": [
+        "--line-length",
+        "80",
+        "--skip-string-normalization"
+    ],
+    "python.formatting.provider": "black",
+    "editor.rulers": [80, 88]
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,9 +18,7 @@
 import os
 import sys
 
-sys.path.insert(
-    0, os.path.split(os.path.split(os.path.dirname(os.path.abspath(
-        __file__)))[0])[0])
+sys.path.insert(0, os.path.abspath("../.."))
 
 from pytest_order import __version__  # noqa: E402
 
@@ -53,7 +51,7 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"pytest-order"
+project = "pytest-order"
 
 # The version info for the project you"re documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -205,8 +203,13 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    ("index", "pytest-order.tex", u"pytest-order Documentation",
-     u"Frank Tobia", "manual"),
+    (
+        "index",
+        "pytest-order.tex",
+        "pytest-order Documentation",
+        "Frank Tobia",
+        "manual",
+    ),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -235,8 +238,13 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ("index", "pytest-order", u"pytest-order Documentation",
-     [u"Frank Tobia"], 1)
+    (
+        "index",
+        "pytest-order",
+        "pytest-order Documentation",
+        ["Frank Tobia"],
+        1,
+    )
 ]
 
 # If true, show URL addresses after external links.
@@ -249,9 +257,15 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    ("index", "pytest-order", u"pytest-order Documentation",
-     u"Frank Tobia", "pytest-order", "One line description of project.",
-     "Miscellaneous"),
+    (
+        "index",
+        "pytest-order",
+        "pytest-order Documentation",
+        "Frank Tobia",
+        "pytest-order",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/perf_tests/test_dependencies.py
+++ b/perf_tests/test_dependencies.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from textwrap import dedent
 
 import pytest
 from perf_tests.util import TimedSorter
@@ -10,21 +11,23 @@ pytest_plugins = ["pytester"]
 def fixture_path_relative(testdir):
     for i_mod in range(10):
         test_name = testdir.tmpdir.join("test_dep_perf{}.py".format(i_mod))
-        test_contents = """
-import pytest
-"""
+        test_contents = "import pytest\n"
         for i in range(40):
-            test_contents += """
-@pytest.mark.dependency(depends=["test_{}"])
-def test_{}():
-    assert True
-""".format(i + 50, i)
+            test_contents += dedent(
+                """
+                @pytest.mark.dependency(depends=["test_{}"])
+                def test_{}():
+                    assert True
+                """
+            ).format(i + 50, i)
         for i in range(60):
-            test_contents += """
-@pytest.mark.dependency
-def test_{}():
-    assert True
-""".format(i + 40)
+            test_contents += dedent(
+                """
+                @pytest.mark.dependency
+                def test_{}():
+                    assert True
+                """
+            ).format(i + 40)
         test_name.write(test_contents)
     yield testdir
 

--- a/perf_tests/test_ordinal.py
+++ b/perf_tests/test_ordinal.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from textwrap import dedent
 
 import pytest
 from perf_tests.util import TimedSorter
@@ -10,15 +11,15 @@ pytest_plugins = ["pytester"]
 def fixture_path_ordinal(testdir):
     for i_mod in range(10):
         test_name = testdir.tmpdir.join("test_performance{}.py".format(i_mod))
-        test_contents = """
-import pytest
-"""
+        test_contents = "import pytest\n"
         for i in range(100):
-            test_contents += """
-@pytest.mark.order({})
-def test_{}():
-    assert True
-""".format(50 - i, i)
+            test_contents += dedent(
+                """
+                @pytest.mark.order({})
+                def test_{}():
+                    assert True
+                """
+            ).format(50 - i, i)
         test_name.write(test_contents)
     yield testdir
 

--- a/perf_tests/test_relative.py
+++ b/perf_tests/test_relative.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from textwrap import dedent
 
 import pytest
 from perf_tests.util import TimedSorter
@@ -10,21 +11,24 @@ pytest_plugins = ["pytester"]
 def fixture_path_relative(testdir):
     for i_mod in range(10):
         test_name = testdir.tmpdir.join(
-            "test_relative_perf{}.py".format(i_mod))
-        test_contents = """
-import pytest
-"""
+            "test_relative_perf{}.py".format(i_mod)
+        )
+        test_contents = "import pytest\n"
         for i in range(40):
-            test_contents += """
-@pytest.mark.order(after="test_{}")
-def test_{}():
-    assert True
-""".format(i + 50, i)
+            test_contents += dedent(
+                """
+                @pytest.mark.order(after="test_{}")
+                def test_{}():
+                    assert True
+                """
+            ).format(i + 50, i)
         for i in range(60):
-            test_contents += """
-def test_{}():
-    assert True
-""".format(i + 40)
+            test_contents += dedent(
+                """
+                def test_{}():
+                    assert True
+                """
+            ).format(i + 40)
         test_name.write(test_contents)
     yield testdir
 

--- a/perf_tests/test_relative_dense.py
+++ b/perf_tests/test_relative_dense.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from textwrap import dedent
 
 import pytest
 from perf_tests.util import TimedSorter
@@ -10,21 +11,24 @@ pytest_plugins = ["pytester"]
 def fixture_path_relative_dense(testdir):
     for i_mod in range(10):
         test_name = testdir.tmpdir.join(
-            "test_relative_dense_perf{}.py".format(i_mod))
-        test_contents = """
-import pytest
-"""
+            "test_relative_dense_perf{}.py".format(i_mod)
+        )
+        test_contents = "import pytest\n"
         for i in range(90):
-            test_contents += """
-@pytest.mark.order(after="test_{}")
-def test_{}():
-    assert True
-""".format(i + 10, i)
+            test_contents += dedent(
+                """
+                @pytest.mark.order(after="test_{}")
+                def test_{}():
+                    assert True
+                """
+            ).format(i + 10, i)
         for i in range(10):
-            test_contents += """
-def test_{}():
-    assert True
-""".format(i + 90)
+            test_contents += dedent(
+                """
+                def test_{}():
+                    assert True
+                """
+            ).format(i + 90)
         test_name.write(test_contents)
     yield testdir
 

--- a/perf_tests/util.py
+++ b/perf_tests/util.py
@@ -11,7 +11,8 @@ class TimedSorter(Sorter):
         self.__class__.elapsed = 0
         start_time = time.time()
         items = super().sort_items()
-        self.__class__.elapsed = ((time.time() - start_time)
-                                  / self.nr_marks * 1000)
+        self.__class__.elapsed = (
+            (time.time() - start_time) / self.nr_marks * 1000
+        )
         print("\nTime per test: {:.3f} ms".format(self.__class__.elapsed))
         return items

--- a/pytest_order/item.py
+++ b/pytest_order/item.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union, Dict, Tuple
 
 from _pytest.python import Function
 
-from pytest_order.settings import Scope, Settings
+from .settings import Scope, Settings
 
 
 class Item:
@@ -41,10 +41,14 @@ class Item:
 class ItemList:
     """Handles a group of items with the same scope."""
 
-    def __init__(self, items: List[Item],
-                 settings: Settings, scope: Scope,
-                 rel_marks: List["RelativeMark"],
-                 dep_marks: List["RelativeMark"]) -> None:
+    def __init__(
+        self,
+        items: List[Item],
+        settings: Settings,
+        scope: Scope,
+        rel_marks: List["RelativeMark"],
+        dep_marks: List["RelativeMark"],
+    ) -> None:
         self.items = items
         self.settings = settings
         self.scope = scope
@@ -95,30 +99,37 @@ class ItemList:
         return sorted_list
 
     def print_unhandled_items(self) -> None:
-        msg = " ".join([mark.item.node_id for mark in self.rel_marks] +
-                       [mark.item.node_id for mark in self.dep_marks])
+        msg = " ".join(
+            [mark.item.node_id for mark in self.rel_marks]
+            + [mark.item.node_id for mark in self.dep_marks]
+        )
         if msg:
             sys.stdout.write(
-                "\nWARNING: cannot execute test relative to others: ")
+                "\nWARNING: cannot execute test relative to others: "
+            )
             sys.stdout.write(msg)
-            sys.stdout.write("- ignoring the marker.\n")
+            sys.stdout.write(" - ignoring the marker.\n")
             sys.stdout.flush()
 
     def number_of_rel_groups(self) -> int:
         return len(self.rel_marks) + len(self.dep_marks)
 
     def handle_rel_marks(self, sorted_list: List[Item]) -> None:
-        self.handle_relative_marks(self.rel_marks, sorted_list,
-                                   self.all_rel_marks)
+        self.handle_relative_marks(
+            self.rel_marks, sorted_list, self.all_rel_marks
+        )
 
     def handle_dep_marks(self, sorted_list: List[Item]) -> None:
-        self.handle_relative_marks(self.dep_marks, sorted_list,
-                                   self.all_dep_marks)
+        self.handle_relative_marks(
+            self.dep_marks, sorted_list, self.all_dep_marks
+        )
 
     @staticmethod
-    def handle_relative_marks(marks: List["RelativeMark"],
-                              sorted_list: List[Item],
-                              all_marks: List["RelativeMark"]):
+    def handle_relative_marks(
+        marks: List["RelativeMark"],
+        sorted_list: List[Item],
+        all_marks: List["RelativeMark"],
+    ):
         for mark in reversed(marks):
             if move_item(mark, sorted_list):
                 marks.remove(mark)
@@ -136,8 +147,9 @@ class ItemGroup:
     Used for sorting groups similar to Item for sorting items.
     """
 
-    def __init__(self, items: Optional[List[Item]] = None,
-                 order: Optional[int] = None) -> None:
+    def __init__(
+        self, items: Optional[List[Item]] = None, order: Optional[int] = None
+    ) -> None:
         self.items = items or []
         self.order = order
         self.nr_rel_items = 0
@@ -161,17 +173,20 @@ class RelativeMark:
     Holds two related items or groups and their relationship.
     """
 
-    def __init__(self, item: Union[Item, ItemGroup],
-                 item_to_move: Union[Item, ItemGroup],
-                 move_after: bool) -> None:
+    def __init__(
+        self,
+        item: Union[Item, ItemGroup],
+        item_to_move: Union[Item, ItemGroup],
+        move_after: bool,
+    ) -> None:
         self.item: Item = item
         self.item_to_move: Item = item_to_move
         self.move_after: bool = move_after
 
 
 def filter_marks(
-        marks: List[RelativeMark],
-        all_items: List[Item]) -> List[RelativeMark]:
+    marks: List[RelativeMark], all_items: List[Item]
+) -> List[RelativeMark]:
     result = []
     for mark in marks:
         if mark.item in all_items and mark.item_to_move in all_items:
@@ -181,11 +196,14 @@ def filter_marks(
     return result
 
 
-def move_item(mark: RelativeMark,
-              sorted_items: List[Union[Item, ItemGroup]]) -> bool:
-    if (mark.item not in sorted_items or
-            mark.item_to_move not in sorted_items or
-            mark.item.nr_rel_items):
+def move_item(
+    mark: RelativeMark, sorted_items: List[Union[Item, ItemGroup]]
+) -> bool:
+    if (
+        mark.item not in sorted_items
+        or mark.item_to_move not in sorted_items
+        or mark.item.nr_rel_items
+    ):
         return False
     pos_item = sorted_items.index(mark.item)
     pos_item_to_move = sorted_items.index(mark.item_to_move)

--- a/pytest_order/plugin.py
+++ b/pytest_order/plugin.py
@@ -7,12 +7,14 @@ from _pytest.config.argparsing import Parser
 from _pytest.main import Session
 from _pytest.python import Function
 
-from pytest_order.sorter import Sorter
+from .sorter import Sorter
 
 
 def pytest_configure(config: Config) -> None:
-    """Register the "order" marker and configure the plugin depending
-     on the CLI options"""
+    """
+    Register the "order" marker and configure the plugin,
+    depending on the CLI options.
+    """
 
     provided_by_pytest_order = (
         "Provided by pytest-order. "
@@ -20,8 +22,8 @@ def pytest_configure(config: Config) -> None:
     )
 
     config_line = (
-            "order: specify ordering information for when tests should run "
-            "in relation to one another. " + provided_by_pytest_order
+        "order: specify ordering information for when tests should run "
+        "in relation to one another. " + provided_by_pytest_order
     )
     config.addinivalue_line("markers", config_line)
 
@@ -35,47 +37,77 @@ def pytest_configure(config: Config) -> None:
         # pseudo method.  Since the class is purely for structuring and `self`
         # is never referenced, this seems reasonable.
         OrderingPlugin.pytest_collection_modifyitems = pytest.hookimpl(
-            function=modify_items, tryfirst=True)
+            function=modify_items, tryfirst=True
+        )
     else:
         OrderingPlugin.pytest_collection_modifyitems = pytest.hookimpl(
-            function=modify_items, trylast=True)
+            function=modify_items, trylast=True
+        )
     config.pluginmanager.register(OrderingPlugin(), "orderingplugin")
 
 
 def pytest_addoption(parser: Parser) -> None:
     """Set up CLI option for pytest"""
     group = parser.getgroup("order")
-    group.addoption("--indulgent-ordering", action="store_true",
-                    dest="indulgent_ordering",
-                    help="Request that the sort order provided by "
-                         "pytest-order be applied before other sorting, "
-                         "allowing the other sorting to have priority")
-    group.addoption("--order-scope", action="store",
-                    dest="order_scope",
-                    help="Defines the scope used for ordering. Possible values"
-                         "are 'session' (default), 'module', and 'class'."
-                         "Ordering is only done inside a scope.")
-    group.addoption("--order-scope-level", action="store", type=int,
-                    dest="order_scope_level",
-                    help="Defines that the given directory level is used as "
-                         "order scope. Cannot be used with --order-scope. "
-                         "The value is a number that defines the "
-                         "hierarchical index of the directories used as "
-                         "order scope, starting with 0 at session scope.")
-    group.addoption("--order-group-scope", action="store",
-                    dest="order_group_scope",
-                    help="Defines the scope used for order groups. Possible "
-                         "values are 'session' (default), 'module', "
-                         "and 'class'. Ordering is first done inside a group, "
-                         "then between groups.")
-    group.addoption("--sparse-ordering", action="store_true",
-                    dest="sparse_ordering",
-                    help="If there are gaps between ordinals they are filled "
-                         "with unordered tests.")
-    group.addoption("--order-dependencies", action="store_true",
-                    dest="order_dependencies",
-                    help="If set, dependencies added by pytest-dependency will"
-                         "be ordered if needed.")
+    group.addoption(
+        "--indulgent-ordering",
+        action="store_true",
+        dest="indulgent_ordering",
+        help=(
+            "Request that the sort order provided by pytest-order be applied "
+            "before other sorting, allowing the other sorting to have priority"
+        ),
+    )
+    group.addoption(
+        "--order-scope",
+        action="store",
+        dest="order_scope",
+        help=(
+            "Defines the scope used for ordering. Possible values are: "
+            "'session' (default), 'module', and 'class'. "
+            "Ordering is only done inside a scope."
+        ),
+    )
+    group.addoption(
+        "--order-scope-level",
+        action="store",
+        type=int,
+        dest="order_scope_level",
+        help=(
+            "Defines that the given directory level is used as order scope. "
+            "Cannot be used with --order-scope. The value is a number "
+            "that defines the hierarchical index of the directories used as "
+            "order scope, starting with 0 at session scope."
+        ),
+    )
+    group.addoption(
+        "--order-group-scope",
+        action="store",
+        dest="order_group_scope",
+        help=(
+            "Defines the scope used for order groups. Possible values are: "
+            " 'session' (default), 'module', and 'class'. "
+            "Ordering is first done inside a group, then between groups."
+        ),
+    )
+    group.addoption(
+        "--sparse-ordering",
+        action="store_true",
+        dest="sparse_ordering",
+        help=(
+            "If there are gaps between ordinals, they are filled "
+            "with unordered tests."
+        ),
+    )
+    group.addoption(
+        "--order-dependencies",
+        action="store_true",
+        dest="order_dependencies",
+        help=(
+            "If set, dependencies added by pytest-dependency will be ordered "
+            "if needed."
+        ),
+    )
 
 
 class OrderingPlugin:
@@ -88,6 +120,7 @@ class OrderingPlugin:
 
 
 def modify_items(
-        session: Session, config: Config, items: List[Function]) -> None:
+    session: Session, config: Config, items: List[Function]
+) -> None:
     sorter = Sorter(config, items)
     items[:] = sorter.sort_items()

--- a/pytest_order/settings.py
+++ b/pytest_order/settings.py
@@ -1,5 +1,5 @@
-from _warnings import warn
 from enum import Enum
+from warnings import warn
 
 from _pytest.config import Config
 
@@ -15,7 +15,7 @@ class Settings:
     valid_scopes = {
         "class": Scope.CLASS,
         "module": Scope.MODULE,
-        "session": Scope.SESSION
+        "session": Scope.SESSION,
     }
 
     def __init__(self, config: Config) -> None:
@@ -26,14 +26,18 @@ class Settings:
             self.scope: Scope = self.valid_scopes[scope]
         else:
             if scope is not None:
-                warn("Unknown order scope '{}', ignoring it. "
-                     "Valid scopes are 'session', 'module' and 'class'."
-                     .format(scope))
+                warn(
+                    "Unknown order scope '{}', ignoring it. "
+                    "Valid scopes are 'session', 'module' and 'class'."
+                    .format(scope)
+                )
             self.scope = Scope.SESSION
         scope_level: int = config.getoption("order_scope_level") or 0
         if scope_level != 0 and self.scope != Scope.SESSION:
-            warn("order-scope-level cannot be used together with "
-                 "--order-scope={}".format(scope))
+            warn(
+                "order-scope-level cannot be used together with "
+                "--order-scope={}".format(scope)
+            )
             scope_level = 0
         self.scope_level: int = scope_level
         group_scope: str = config.getoption("order_group_scope")
@@ -41,13 +45,17 @@ class Settings:
             self.group_scope: Scope = self.valid_scopes[group_scope]
         else:
             if group_scope is not None:
-                warn("Unknown order group scope '{}', ignoring it. "
-                     "Valid scopes are 'session', 'module' and 'class'."
-                     .format(group_scope))
+                warn(
+                    "Unknown order group scope '{}', ignoring it. "
+                    "Valid scopes are 'session', 'module' and 'class'."
+                    .format(group_scope)
+                )
             self.group_scope = self.scope
         if self.group_scope.value > self.scope.value:
             warn("Group scope is larger than order scope, ignoring it.")
             self.group_scope = self.scope
         auto_mark_dep = config.getini("automark_dependency")
-        self.auto_mark_dep = (auto_mark_dep and auto_mark_dep.lower()
-                              in ("1", "yes", "y", "true", "t", "on"))
+        self.auto_mark_dep = (
+            auto_mark_dep
+            and auto_mark_dep.lower() in ("1", "yes", "y", "true", "t", "on")
+        )

--- a/pytest_order/sorter.py
+++ b/pytest_order/sorter.py
@@ -125,7 +125,9 @@ class Sorter:
                 scope = scope_from_name(mark.kwargs.get("scope", "module"))
                 prefix = scoped_node_id(item.node_id, scope)
                 for name in dependent_mark:
-                    dep_marks.setdefault((name, scope, prefix), []).append(item)
+                    dep_marks.setdefault((name, scope, prefix), []).append(
+                        item
+                    )
                     item.inc_rel_marks()
             # we always collect the names of the dependent items, because
             # we need them in both cases
@@ -400,7 +402,9 @@ class ScopeSorter:
             module_groups.append(module_group)
         return module_groups
 
-    def sort_items_in_scope(self, items: List[Item], scope: Scope) -> ItemGroup:
+    def sort_items_in_scope(
+        self, items: List[Item], scope: Scope
+    ) -> ItemGroup:
         item_list = ItemList(
             items, self.settings, scope, self.rel_marks, self.dep_marks
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,9 @@ def item_names_for(testdir):
 
         items = testdir.getitems(tests_content)
         hook = items[0].config.hook
-        hook.pytest_collection_modifyitems(session=items[0].session,
-                                           config=items[0].config, items=items)
+        hook.pytest_collection_modifyitems(
+            session=items[0].session, config=items[0].config, items=items
+        )
 
         return [name(item) for item in items]
 
@@ -25,7 +26,7 @@ def item_names_for(testdir):
 @pytest.fixture
 def test_path(testdir):
     testdir.tmpdir.join("pytest.ini").write(
-        "[pytest]\n" "console_output_style = classic"
+        "[pytest]\nconsole_output_style = classic"
     )
     yield testdir
 

--- a/tests/test_class_marks.py
+++ b/tests/test_class_marks.py
@@ -2,163 +2,180 @@
 
 
 def test_ordinal_class_marks(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(1)
-    class Test1:
-        def test_1(self): pass
-        def test_2(self): pass
+        @pytest.mark.order(1)
+        class Test1:
+            def test_1(self): pass
+            def test_2(self): pass
 
-    @pytest.mark.order(0)
-    class Test2:
-        def test_1(self): pass
-        def test_2(self): pass
+        @pytest.mark.order(0)
+        class Test2:
+            def test_1(self): pass
+            def test_2(self): pass
 
-    """
-
+        """
+    )
     assert item_names_for(tests_content) == [
         "Test2::test_1", "Test2::test_2", "Test1::test_1", "Test1::test_2"
     ]
 
 
 def test_after_class_mark(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(after="Test2")
-    class Test1:
-        def test_1(self): pass
-        def test_2(self): pass
+        @pytest.mark.order(after="Test2")
+        class Test1:
+            def test_1(self): pass
+            def test_2(self): pass
 
-    class Test2:
-        def test_1(self): pass
-        def test_2(self): pass
-    """
-
+        class Test2:
+            def test_1(self): pass
+            def test_2(self): pass
+        """
+    )
     assert item_names_for(tests_content) == [
         "Test2::test_1", "Test2::test_2", "Test1::test_1", "Test1::test_2"
     ]
 
 
 def test_invalid_class_mark(item_names_for, capsys):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(after="Test3")
-    class Test1:
-        def test_1(self): pass
-        def test_2(self): pass
+        @pytest.mark.order(after="Test3")
+        class Test1:
+            def test_1(self): pass
+            def test_2(self): pass
 
-    class Test2:
-        def test_1(self): pass
-        def test_2(self): pass
-    """
-
+        class Test2:
+            def test_1(self): pass
+            def test_2(self): pass
+        """
+    )
     assert item_names_for(tests_content) == [
         "Test1::test_1", "Test1::test_2", "Test2::test_1", "Test2::test_2"
     ]
     out, err = capsys.readouterr()
-    assert ("WARNING: cannot execute 'test_2' relative to others: 'Test3' "
-            "- ignoring the marker" in out)
+    assert (
+        "WARNING: cannot execute 'test_2' relative to others: "
+        "'Test3' - ignoring the marker"
+        in out
+    )
 
 
 def test_before_class_mark(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    class Test1:
-        def test_1(self): pass
-        def test_2(self): pass
+        class Test1:
+            def test_1(self): pass
+            def test_2(self): pass
 
-    @pytest.mark.order(before="Test1")
-    class Test2:
-        def test_1(self): pass
-        def test_2(self): pass
-    """
-
+        @pytest.mark.order(before="Test1")
+        class Test2:
+            def test_1(self): pass
+            def test_2(self): pass
+        """
+    )
     assert item_names_for(tests_content) == [
         "Test2::test_1", "Test2::test_2", "Test1::test_1", "Test1::test_2"
     ]
 
 
 def test_after_class_marks_for_single_test_in_class(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(after="Test2::test_1")
-    class Test1:
-        def test_1(self): pass
-        def test_2(self): pass
+        @pytest.mark.order(after="Test2::test_1")
+        class Test1:
+            def test_1(self): pass
+            def test_2(self): pass
 
-    class Test2:
-        def test_1(self): pass
-        def test_2(self): pass
-    """
-
+        class Test2:
+            def test_1(self): pass
+            def test_2(self): pass
+        """
+    )
     assert item_names_for(tests_content) == [
         "Test2::test_1", "Test1::test_1", "Test1::test_2", "Test2::test_2"
     ]
 
 
 def test_before_class_marks_for_single_test_in_class(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    class Test1:
-        def test_1(self): pass
-        def test_2(self): pass
+        class Test1:
+            def test_1(self): pass
+            def test_2(self): pass
 
-    @pytest.mark.order(before="Test1::test_2")
-    class Test2:
-        def test_1(self): pass
-        def test_2(self): pass
-    """
-
+        @pytest.mark.order(before="Test1::test_2")
+        class Test2:
+            def test_1(self): pass
+            def test_2(self): pass
+        """
+    )
     assert item_names_for(tests_content) == [
         "Test1::test_1", "Test2::test_1", "Test2::test_2", "Test1::test_2"
     ]
 
 
 def test_after_class_marks_for_single_test(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(after="test_1")
-    class Test1:
-        def test_1(self): pass
-        def test_2(self): pass
+        @pytest.mark.order(after="test_1")
+        class Test1:
+            def test_1(self): pass
+            def test_2(self): pass
 
-    def test_1(): pass
+        def test_1(): pass
 
-    class Test2:
-        def test_1(self): pass
-        def test_2(self): pass
-    """
-
+        class Test2:
+            def test_1(self): pass
+            def test_2(self): pass
+        """
+    )
     assert item_names_for(tests_content) == [
-        "test_1", "Test1::test_1", "Test1::test_2",
-        "Test2::test_1", "Test2::test_2"
+        "test_1",
+        "Test1::test_1",
+        "Test1::test_2",
+        "Test2::test_1",
+        "Test2::test_2",
     ]
 
 
 def test_before_class_marks_for_single_test(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    def test_1(): pass
+        def test_1(): pass
 
-    class Test1:
-        def test_1(self): pass
-        def test_2(self): pass
+        class Test1:
+            def test_1(self): pass
+            def test_2(self): pass
 
-    @pytest.mark.order(before="test_1")
-    class Test2:
-        def test_1(self): pass
-        def test_2(self): pass
-    """
-
+        @pytest.mark.order(before="test_1")
+        class Test2:
+            def test_1(self): pass
+            def test_2(self): pass
+        """
+    )
     assert item_names_for(tests_content) == [
-        "Test2::test_1", "Test2::test_2", "test_1",
-        "Test1::test_1", "Test1::test_2"
+        "Test2::test_1",
+        "Test2::test_2",
+        "test_1",
+        "Test1::test_1",
+        "Test1::test_2",
     ]

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -4,115 +4,127 @@ import pytest
 
 
 def test_ignore_order_with_dependency(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.dependency()
-    def test_a():
-        pass
+        @pytest.mark.dependency()
+        def test_a():
+            pass
 
-    @pytest.mark.dependency(depends=["test_a"])
-    @pytest.mark.order("first")
-    def test_b():
-        pass
-    """
+        @pytest.mark.dependency(depends=["test_a"])
+        @pytest.mark.order("first")
+        def test_b():
+            pass
+        """
+    )
     assert item_names_for(tests_content) == ["test_a", "test_b"]
 
 
 def test_order_with_dependency(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.dependency(depends=["test_b"])
-    @pytest.mark.order("second")
-    def test_a():
-        pass
+        @pytest.mark.dependency(depends=["test_b"])
+        @pytest.mark.order("second")
+        def test_a():
+            pass
 
-    @pytest.mark.dependency()
-    def test_b():
-        pass
-    """
+        @pytest.mark.dependency()
+        def test_b():
+            pass
+        """
+    )
     assert item_names_for(tests_content) == ["test_b", "test_a"]
 
 
 @pytest.fixture(scope="module")
 def ordered_test():
-    yield """
-    import pytest
+    yield (
+        """
+        import pytest
 
-    @pytest.mark.dependency()
-    def test_a():
-        pass
+        @pytest.mark.dependency()
+        def test_a():
+            pass
 
-    @pytest.mark.dependency(depends=["test_a"])
-    def test_b():
-        pass
-    """
+        @pytest.mark.dependency(depends=["test_a"])
+        def test_b():
+            pass
+        """
+    )
 
 
 def test_dependency_already_ordered_default(ordered_test, item_names_for):
     assert item_names_for(ordered_test) == ["test_a", "test_b"]
 
 
-def test_dependency_already_ordered_with_ordering(ordered_test,
-                                                  item_names_for,
-                                                  order_dependencies):
+def test_dependency_already_ordered_with_ordering(
+    ordered_test, item_names_for, order_dependencies
+):
     assert item_names_for(ordered_test) == ["test_a", "test_b"]
 
 
 @pytest.fixture(scope="module")
 def order_dependency_test():
-    yield """
-    import pytest
+    yield (
+        """
+        import pytest
 
-    @pytest.mark.dependency(depends=["test_b"])
-    def test_a():
-        pass
+        @pytest.mark.dependency(depends=["test_b"])
+        def test_a():
+            pass
 
-    @pytest.mark.dependency()
-    def test_b():
-        pass
-    """
+        @pytest.mark.dependency()
+        def test_b():
+            pass
+        """
+    )
 
 
 def test_order_dependency_default(order_dependency_test, item_names_for):
     assert item_names_for(order_dependency_test) == ["test_a", "test_b"]
 
 
-def test_order_dependency_ordered(order_dependency_test, item_names_for,
-                                  order_dependencies):
+def test_order_dependency_ordered(
+    order_dependency_test, item_names_for, order_dependencies
+):
     assert item_names_for(order_dependency_test) == ["test_b", "test_a"]
 
 
 @pytest.fixture(scope="module")
 def multiple_dependencies_test():
-    yield """
-    import pytest
+    yield (
+        """
+        import pytest
 
-    @pytest.mark.dependency(depends=["test_b", "test_c"])
-    def test_a():
-        pass
+        @pytest.mark.dependency(depends=["test_b", "test_c"])
+        def test_a():
+            pass
 
-    @pytest.mark.dependency()
-    def test_b():
-        pass
+        @pytest.mark.dependency()
+        def test_b():
+            pass
 
-    @pytest.mark.dependency()
-    def test_c():
-        pass
-    """
+        @pytest.mark.dependency()
+        def test_c():
+            pass
+        """
+    )
 
 
-def test_order_multiple_dependencies_default(multiple_dependencies_test,
-                                             item_names_for):
+def test_order_multiple_dependencies_default(
+    multiple_dependencies_test, item_names_for
+):
     assert item_names_for(multiple_dependencies_test) == [
         "test_a", "test_b", "test_c"
     ]
 
 
-def test_order_multiple_dependencies_ordered(multiple_dependencies_test,
-                                             item_names_for,
-                                             order_dependencies):
+def test_order_multiple_dependencies_ordered(
+    multiple_dependencies_test, item_names_for, order_dependencies
+):
     assert item_names_for(multiple_dependencies_test) == [
         "test_b", "test_c", "test_a"
     ]
@@ -121,19 +133,21 @@ def test_order_multiple_dependencies_ordered(multiple_dependencies_test,
 @pytest.fixture
 def no_dep_marks(test_path):
     test_path.makepyfile(
-        test_auto="""
-    import pytest
+        test_auto=(
+            """
+            import pytest
 
-    @pytest.mark.dependency(depends=["test_b", "test_c"])
-    def test_a():
-        pass
+            @pytest.mark.dependency(depends=["test_b", "test_c"])
+            def test_a():
+                pass
 
-    def test_b():
-        pass
+            def test_b():
+                pass
 
-    def test_c():
-        pass
-    """
+            def test_c():
+                pass
+            """
+        )
     )
     yield test_path
 
@@ -141,55 +155,61 @@ def no_dep_marks(test_path):
 def test_order_dependencies_no_auto_mark(no_dep_marks):
     no_dep_marks.makefile(
         ".ini",
-        pytest="""
-        [pytest]
-        automark_dependency = 0
-        console_output_style = classic
-        """
+        pytest=(
+            """
+            [pytest]
+            automark_dependency = 0
+            console_output_style = classic
+            """
+        ),
     )
     result = no_dep_marks.runpytest("-v", "--order-dependencies")
     result.assert_outcomes(passed=2, skipped=1)
     result.stdout.fnmatch_lines([
         "test_auto.py::test_a SKIPPED*",
         "test_auto.py::test_b PASSED",
-        "test_auto.py::test_c PASSED"
+        "test_auto.py::test_c PASSED",
     ])
 
 
 def test_order_dependencies_auto_mark(no_dep_marks):
     no_dep_marks.makefile(
         ".ini",
-        pytest="""
-        [pytest]
-        automark_dependency = 1
-        console_output_style = classic
-        """
+        pytest=(
+            """
+            [pytest]
+            automark_dependency = 1
+            console_output_style = classic
+            """
+        ),
     )
     result = no_dep_marks.runpytest("-v", "--order-dependencies")
     result.assert_outcomes(passed=3, failed=0)
     result.stdout.fnmatch_lines([
         "test_auto.py::test_b PASSED",
         "test_auto.py::test_c PASSED",
-        "test_auto.py::test_a PASSED"
+        "test_auto.py::test_a PASSED",
     ])
 
 
 @pytest.fixture(scope="module")
 def named_dependency_test():
-    yield """
-    import pytest
+    yield (
+        """
+        import pytest
 
-    @pytest.mark.dependency(depends=["my_test"])
-    def test_a():
-        pass
+        @pytest.mark.dependency(depends=["my_test"])
+        def test_a():
+            pass
 
-    @pytest.mark.dependency(name="my_test")
-    def test_b():
-        pass
+        @pytest.mark.dependency(name="my_test")
+        def test_b():
+            pass
 
-    def test_c():
-        pass
-    """
+        def test_c():
+            pass
+        """
+    )
 
 
 def test_order_named_dependency_default(named_dependency_test, item_names_for):
@@ -198,165 +218,188 @@ def test_order_named_dependency_default(named_dependency_test, item_names_for):
     ]
 
 
-def test_order_named_dependency_ordered(named_dependency_test,
-                                        item_names_for, order_dependencies):
+def test_order_named_dependency_ordered(
+    named_dependency_test, item_names_for, order_dependencies
+):
     assert item_names_for(named_dependency_test) == [
         "test_b", "test_a", "test_c"
     ]
 
 
 def test_dependency_in_class(item_names_for, order_dependencies):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    class Test:
-        @pytest.mark.dependency(depends=["Test::test_c"])
-        def test_a(self):
-            assert True
+        class Test:
+            @pytest.mark.dependency(depends=["Test::test_c"])
+            def test_a(self):
+                assert True
 
-        @pytest.mark.dependency(depends=["Test::test_c"])
-        def test_b(self):
-            assert True
+            @pytest.mark.dependency(depends=["Test::test_c"])
+            def test_b(self):
+                assert True
 
-        @pytest.mark.dependency()
-        def test_c(self):
-            assert True
-    """
+            @pytest.mark.dependency()
+            def test_c(self):
+                assert True
+        """
+    )
     assert item_names_for(tests_content) == [
         "Test::test_c", "Test::test_a", "Test::test_b"
     ]
 
 
-def test_unresolved_dependency_in_class(item_names_for, order_dependencies,
-                                        capsys):
-    tests_content = """
-    import pytest
+def test_unresolved_dependency_in_class(
+    item_names_for, order_dependencies, capsys
+):
+    tests_content = (
+        """
+        import pytest
 
-    class Test:
-        @pytest.mark.dependency(depends=["test_c"])
-        def test_a(self):
-            assert True
+        class Test:
+            @pytest.mark.dependency(depends=["test_c"])
+            def test_a(self):
+                assert True
 
-        @pytest.mark.dependency(depends=["test_c"])
-        def test_b(self):
-            assert True
+            @pytest.mark.dependency(depends=["test_c"])
+            def test_b(self):
+                assert True
 
-        @pytest.mark.dependency()
-        def test_c(self):
-            assert True
-    """
+            @pytest.mark.dependency()
+            def test_c(self):
+                assert True
+        """
+    )
     assert item_names_for(tests_content) == [
         "Test::test_a", "Test::test_b", "Test::test_c"
     ]
     out, err = capsys.readouterr()
-    warning = ("Cannot resolve the dependency marker "
-               "'test_c' - ignoring it")
+    warning = "Cannot resolve the dependency marker 'test_c' - ignoring it"
     assert warning in out
 
 
 def test_named_dependency_in_class(item_names_for, order_dependencies):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    class Test:
-        @pytest.mark.dependency(name="test_1", depends=["test_3"])
-        def test_a(self):
-            assert True
+        class Test:
+            @pytest.mark.dependency(name="test_1", depends=["test_3"])
+            def test_a(self):
+                assert True
 
-        @pytest.mark.dependency(name="test_2", depends=["test_3"])
-        def test_b(self):
-            assert True
+            @pytest.mark.dependency(name="test_2", depends=["test_3"])
+            def test_b(self):
+                assert True
 
-        @pytest.mark.dependency(name="test_3")
-        def test_c(self):
-            assert True
-    """
+            @pytest.mark.dependency(name="test_3")
+            def test_c(self):
+                assert True
+        """
+    )
     assert item_names_for(tests_content) == [
         "Test::test_c", "Test::test_a", "Test::test_b"
     ]
 
 
 def test_dependencies_in_classes(item_names_for, order_dependencies):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    class TestA:
-        @pytest.mark.dependency(depends=["test_2"])
-        def test_a(self):
-            assert True
+        class TestA:
+            @pytest.mark.dependency(depends=["test_2"])
+            def test_a(self):
+                assert True
 
-        @pytest.mark.dependency(depends=["TestB::test_b"])
-        def test_b(self):
-            assert True
+            @pytest.mark.dependency(depends=["TestB::test_b"])
+            def test_b(self):
+                assert True
 
-        def test_c(self):
-            assert True
+            def test_c(self):
+                assert True
 
-    class TestB:
-        @pytest.mark.dependency(name="test_2")
-        def test_a(self):
-            assert True
+        class TestB:
+            @pytest.mark.dependency(name="test_2")
+            def test_a(self):
+                assert True
 
-        @pytest.mark.dependency()
-        def test_b(self):
-            assert True
+            @pytest.mark.dependency()
+            def test_b(self):
+                assert True
 
-        def test_c(self):
-            assert True
-    """
+            def test_c(self):
+                assert True
+        """
+    )
     assert item_names_for(tests_content) == [
-        "TestA::test_c", "TestB::test_a", "TestA::test_a",
-        "TestB::test_b", "TestA::test_b", "TestB::test_c"
+        "TestA::test_c",
+        "TestB::test_a",
+        "TestA::test_a",
+        "TestB::test_b",
+        "TestA::test_b",
+        "TestB::test_c",
     ]
 
 
 def test_class_scope_dependencies(item_names_for, order_dependencies):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    class TestA:
-        @pytest.mark.dependency(depends=["test_c"], scope='class')
-        def test_a(self):
-            assert True
+        class TestA:
+            @pytest.mark.dependency(depends=["test_c"], scope='class')
+            def test_a(self):
+                assert True
 
-        def test_b(self):
-            assert True
+            def test_b(self):
+                assert True
 
-        @pytest.mark.dependency
-        def test_c(self):
-            assert True
-    """
+            @pytest.mark.dependency
+            def test_c(self):
+                assert True
+        """
+    )
     assert item_names_for(tests_content) == [
         "TestA::test_b", "TestA::test_c", "TestA::test_a"
     ]
 
 
-@pytest.mark.skipif(pytest.__version__.startswith("3.7."),
-                    reason="pytest-dependency < 0.5 does not support "
-                           "session scope")
+@pytest.mark.skipif(
+    pytest.__version__.startswith("3.7."),
+    reason="pytest-dependency < 0.5 does not support session scope",
+)
 def test_named_dependency_in_modules(test_path):
     test_path.makepyfile(
-        test_ndep1="""
-    import pytest
+        test_ndep1=(
+            """
+            import pytest
 
-    class Test1:
-        def test_one(self):
-            assert True
+            class Test1:
+                def test_one(self):
+                    assert True
 
-        @pytest.mark.dependency(depends=['dep2_test_one'], scope='session')
-        def test_two(self):
-            assert True
-    """,
-        test_ndep2="""
-    import pytest
+                @pytest.mark.dependency(
+                    depends=['dep2_test_one'], scope='session'
+                )
+                def test_two(self):
+                    assert True
+            """
+        ),
+        test_ndep2=(
+            """
+            import pytest
 
-    @pytest.mark.dependency(name='dep2_test_one')
-    def test_one():
-        assert True
+            @pytest.mark.dependency(name='dep2_test_one')
+            def test_one():
+                assert True
 
-    def test_two():
-        assert True
-    """)
+            def test_two():
+                assert True
+            """
+        ),
+    )
 
     result = test_path.runpytest("-v", "--order-dependencies")
     result.assert_outcomes(passed=4, failed=0)
@@ -368,33 +411,41 @@ def test_named_dependency_in_modules(test_path):
     ])
 
 
-@pytest.mark.skipif(pytest.__version__.startswith("3.7."),
-                    reason="pytest-dependency < 0.5 does not support "
-                           "session scope")
+@pytest.mark.skipif(
+    pytest.__version__.startswith("3.7."),
+    reason="pytest-dependency < 0.5 does not support session scope",
+)
 def test_dependency_in_modules(test_path):
     test_path.makepyfile(
-        test_unnamed_dep1="""
-    import pytest
+        test_unnamed_dep1=(
+            """
+            import pytest
 
-    class Test1:
-        def test_one(self):
-            assert True
+            class Test1:
+                def test_one(self):
+                    assert True
 
-        @pytest.mark.dependency(depends=['test_unnamed_dep2.py::test_one'],
-                                scope='session')
-        def test_two(self):
-            assert True
-    """,
-        test_unnamed_dep2="""
-    import pytest
+                @pytest.mark.dependency(
+                    depends=['test_unnamed_dep2.py::test_one'],
+                    scope='session',
+                )
+                def test_two(self):
+                    assert True
+            """
+        ),
+        test_unnamed_dep2=(
+            """
+            import pytest
 
-    @pytest.mark.dependency
-    def test_one():
-        assert True
+            @pytest.mark.dependency
+            def test_one():
+                assert True
 
-    def test_two():
-        assert True
-    """)
+            def test_two():
+                assert True
+            """
+        ),
+    )
 
     result = test_path.runpytest("-v", "--order-dependencies")
     result.assert_outcomes(passed=4, failed=0)
@@ -410,28 +461,33 @@ def test_same_dependency_in_modules(test_path):
     # regression test - make sure that the same dependency in different
     # modules works correctly
     test_path.makepyfile(
-        test_module_dep1="""
-    import pytest
+        test_module_dep1=(
+            """
+            import pytest
 
-    @pytest.mark.dependency(depends=['test_two'])
-    def test_one():
-        assert True
+            @pytest.mark.dependency(depends=['test_two'])
+            def test_one():
+                assert True
 
-    @pytest.mark.dependency
-    def test_two():
-        assert True
-    """,
-        test_module_dep2="""
-    import pytest
+            @pytest.mark.dependency
+            def test_two():
+                assert True
+            """
+        ),
+        test_module_dep2=(
+            """
+            import pytest
 
-    @pytest.mark.dependency(depends=['test_two'])
-    def test_one():
-        assert True
+            @pytest.mark.dependency(depends=['test_two'])
+            def test_one():
+                assert True
 
-    @pytest.mark.dependency
-    def test_two():
-        assert True
-    """)
+            @pytest.mark.dependency
+            def test_two():
+                assert True
+            """
+        ),
+    )
     result = test_path.runpytest("-v", "--order-dependencies")
     result.assert_outcomes(passed=4, failed=0)
     result.stdout.fnmatch_lines([
@@ -443,40 +499,43 @@ def test_same_dependency_in_modules(test_path):
 
 
 def test_unknown_dependency(item_names_for, order_dependencies, capsys):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    class Test:
-        def test_a(self):
-            assert True
+        class Test:
+            def test_a(self):
+                assert True
 
-        @pytest.mark.dependency(depends=["test_3"])
-        def test_b(self):
-            assert True
+            @pytest.mark.dependency(depends=["test_3"])
+            def test_b(self):
+                assert True
 
-        def test_c(self):
-            assert True
-    """
+            def test_c(self):
+                assert True
+        """
+    )
     assert item_names_for(tests_content) == [
         "Test::test_a", "Test::test_b", "Test::test_c"
     ]
     out, err = capsys.readouterr()
-    warning = ("Cannot resolve the dependency marker "
-               "'test_3' - ignoring it.")
+    warning = "Cannot resolve the dependency marker 'test_3' - ignoring it."
     assert warning in out
 
 
 def test_unsupported_order_with_dependency(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    @pytest.mark.dependency(depends=["test_2"])
-    @pytest.mark.order("unknown")
-    def test_1():
-        pass
+        @pytest.mark.dependency(depends=["test_2"])
+        @pytest.mark.order("unknown")
+        def test_1():
+            pass
 
-    def test_2():
-        pass
-    """
+        def test_2():
+            pass
+        """
+    )
     with pytest.warns(UserWarning, match="Unknown order attribute:'unknown'"):
         assert item_names_for(test_content) == ["test_1", "test_2"]

--- a/tests/test_indulgent_ordering.py
+++ b/tests/test_indulgent_ordering.py
@@ -3,26 +3,29 @@
 
 def test_run_marker_registered(test_path):
     test_path.makepyfile(
-        test_failing="""
-    import pytest
+        test_failing=(
+            """
+            import pytest
 
-    @pytest.mark.order("second")
-    def test_me_second():
-        assert True
+            @pytest.mark.order("second")
+            def test_me_second():
+                assert True
 
-    def test_that_fails():
-        assert False
+            def test_that_fails():
+                assert False
 
-    @pytest.mark.order("first")
-    def test_me_first():
-        assert True
-    """)
+            @pytest.mark.order("first")
+            def test_me_first():
+                assert True
+            """
+        )
+    )
     result = test_path.runpytest("-v")
     result.assert_outcomes(passed=2, failed=1)
     result.stdout.fnmatch_lines([
         "test_failing.py::test_me_first PASSED",
         "test_failing.py::test_me_second PASSED",
-        "test_failing.py::test_that_fails FAILED"
+        "test_failing.py::test_that_fails FAILED",
     ])
 
     result = test_path.runpytest("-v", "--ff", "--indulgent-ordering")
@@ -30,5 +33,5 @@ def test_run_marker_registered(test_path):
     result.stdout.fnmatch_lines([
         "test_failing.py::test_that_fails FAILED",
         "test_failing.py::test_me_first PASSED",
-        "test_failing.py::test_me_second PASSED"
+        "test_failing.py::test_me_second PASSED",
     ])

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -12,8 +12,10 @@ def test_version_exists():
 
 def test_version_valid():
     # check for PEP 440 conform version
-    assert re.match(r"\d+(\.\d+)*((a|b|rc)\d+)?(\.post\d)?(\.dev\d)?$",
-                    pytest_order.__version__)
+    assert re.match(
+        r"\d+(\.\d+)*((a|b|rc)\d+)?(\.post\d)?(\.dev\d)?$",
+        pytest_order.__version__,
+    )
 
 
 def test_markers_registered(capsys):

--- a/tests/test_order_group_scope.py
+++ b/tests/test_order_group_scope.py
@@ -6,72 +6,82 @@ import pytest
 @pytest.fixture
 def fixture_path(test_path):
     test_path.makepyfile(
-        test_clss="""
-    import pytest
+        test_clss=(
+            """
+            import pytest
 
-    class Test1:
-        @pytest.mark.order(2)
-        def test_two(self):
-            assert True
+            class Test1:
+                @pytest.mark.order(2)
+                def test_two(self):
+                    assert True
 
-        def test_one(self):
-            assert True
+                def test_one(self):
+                    assert True
 
-    class Test2:
-        def test_two(self):
-            assert True
+            class Test2:
+                def test_two(self):
+                    assert True
 
-        @pytest.mark.order(1)
-        def test_one(self):
-            assert True
+                @pytest.mark.order(1)
+                def test_one(self):
+                    assert True
 
-    @pytest.mark.order(-1)
-    def test_two():
-        assert True
+            @pytest.mark.order(-1)
+            def test_two():
+                assert True
 
-    def test_one():
-        assert True
-    """,
-        test_fcts1="""
-    import pytest
+            def test_one():
+                assert True
+            """
+        ),
+        test_fcts1=(
+            """
+            import pytest
 
-    @pytest.mark.order(5)
-    def test1_two():
-        assert True
+            @pytest.mark.order(5)
+            def test1_two():
+                assert True
 
-    def test1_one():
-        assert True
-    """,
-        test_fcts2="""
-    import pytest
+            def test1_one():
+                assert True
+            """
+        ),
+        test_fcts2=(
+            """
+            import pytest
 
-    @pytest.mark.order(0)
-    def test2_two():
-        assert True
+            @pytest.mark.order(0)
+            def test2_two():
+                assert True
 
-    def test2_one():
-        assert True
-    """,
-        test_fcts3="""
-    import pytest
+            def test2_one():
+                assert True
+            """
+        ),
+        test_fcts3=(
+            """
+            import pytest
 
-    @pytest.mark.order(-2)
-    def test3_two():
-        assert True
+            @pytest.mark.order(-2)
+            def test3_two():
+                assert True
 
-    def test3_one():
-        assert True
-    """,
-        test_fcts4="""
-    import pytest
+            def test3_one():
+                assert True
+            """
+        ),
+        test_fcts4=(
+            """
+            import pytest
 
-    def test4_one():
-        assert True
+            def test4_one():
+                assert True
 
-    def test4_two():
-        assert True
-    """)
-
+            def test4_two():
+                assert True
+            """
+        ),
+    )
     yield test_path
 
 
@@ -92,7 +102,7 @@ def test_session_scope(fixture_path):
         "test_fcts4.py::test4_one PASSED",
         "test_fcts4.py::test4_two PASSED",
         "test_fcts3.py::test3_two PASSED",
-        "test_clss.py::test_two PASSED"
+        "test_clss.py::test_two PASSED",
     ])
 
 
@@ -113,7 +123,7 @@ def test_module_group_scope(fixture_path):
         "test_fcts4.py::test4_one PASSED",
         "test_fcts4.py::test4_two PASSED",
         "test_fcts3.py::test3_one PASSED",
-        "test_fcts3.py::test3_two PASSED"
+        "test_fcts3.py::test3_two PASSED",
     ])
 
 
@@ -134,13 +144,14 @@ def test_class_group_scope(fixture_path):
         "test_fcts4.py::test4_one PASSED",
         "test_fcts4.py::test4_two PASSED",
         "test_fcts3.py::test3_one PASSED",
-        "test_fcts3.py::test3_two PASSED"
+        "test_fcts3.py::test3_two PASSED",
     ])
 
 
 def test_class_group_scope_module_scope(fixture_path):
-    result = fixture_path.runpytest("-v", "--order-group-scope=class",
-                                    "--order-scope=module")
+    result = fixture_path.runpytest(
+        "-v", "--order-group-scope=class", "--order-scope=module"
+    )
     result.assert_outcomes(passed=14, failed=0)
     result.stdout.fnmatch_lines([
         "test_clss.py::Test2::test_one PASSED",
@@ -156,12 +167,14 @@ def test_class_group_scope_module_scope(fixture_path):
         "test_fcts3.py::test3_one PASSED",
         "test_fcts3.py::test3_two PASSED",
         "test_fcts4.py::test4_one PASSED",
-        "test_fcts4.py::test4_two PASSED"
+        "test_fcts4.py::test4_two PASSED",
     ])
 
 
-@pytest.mark.skipif(pytest.__version__.startswith("3.7."),
-                    reason="Warning does not appear in output in pytest < 3.8")
+@pytest.mark.skipif(
+    pytest.__version__.startswith("3.7."),
+    reason="Warning does not appear in output in pytest < 3.8",
+)
 def test_invalid_scope(fixture_path):
     result = fixture_path.runpytest("-v", "--order-group-scope=function")
     result.assert_outcomes(passed=14, failed=0)
@@ -170,11 +183,14 @@ def test_invalid_scope(fixture_path):
     ])
 
 
-@pytest.mark.skipif(pytest.__version__.startswith("3.7."),
-                    reason="Warning does not appear in output in pytest < 3.8")
+@pytest.mark.skipif(
+    pytest.__version__.startswith("3.7."),
+    reason="Warning does not appear in output in pytest < 3.8",
+)
 def test_ignored_scope(fixture_path):
-    result = fixture_path.runpytest("-v", "--order-group-scope=session",
-                                    "--order-scope=module")
+    result = fixture_path.runpytest(
+        "-v", "--order-group-scope=session", "--order-scope=module"
+    )
     result.assert_outcomes(passed=14, failed=0)
     result.stdout.fnmatch_lines([
         "*UserWarning: Group scope is larger than order scope, ignoring it."

--- a/tests/test_order_group_scope_dep.py
+++ b/tests/test_order_group_scope_dep.py
@@ -6,67 +6,79 @@ import pytest
 @pytest.fixture
 def fixture_path(test_path):
     test_path.makepyfile(
-        test_dep1="""
-    import pytest
+        test_dep1=(
+            """
+            import pytest
 
-    class Test1:
-        @pytest.mark.dependency(depends=['Test2::test_two'])
-        def test_one(self):
-            assert True
+            class Test1:
+                @pytest.mark.dependency(depends=['Test2::test_two'])
+                def test_one(self):
+                    assert True
 
-        @pytest.mark.dependency(depends=['test_three'], scope="class")
-        def test_two(self):
-            assert True
+                @pytest.mark.dependency(depends=['test_three'], scope="class")
+                def test_two(self):
+                    assert True
 
-        @pytest.mark.dependency
-        def test_three(self):
-            assert True
+                @pytest.mark.dependency
+                def test_three(self):
+                    assert True
 
-    class Test2:
-        def test_one(self):
-            assert True
+            class Test2:
+                def test_one(self):
+                    assert True
 
-        @pytest.mark.dependency(depends=['test_dep3.py::test_two'],
-                                scope='session')
-        def test_two(self):
-            assert True
-    """,
-        test_dep2="""
-    import pytest
+                @pytest.mark.dependency(
+                    depends=['test_dep3.py::test_two'], scope='session'
+                )
+                def test_two(self):
+                    assert True
+            """
+        ),
+        test_dep2=(
+            """
+            import pytest
 
-    @pytest.mark.dependency(depends=['test_dep3.py::test_two'],
-                            scope='session')
-    def test_one():
-        assert True
+            @pytest.mark.dependency(
+                depends=['test_dep3.py::test_two'], scope='session'
+            )
+            def test_one():
+                assert True
 
-    def test_two():
-        assert True
-    """,
-        test_dep3="""
-    import pytest
+            def test_two():
+                assert True
+            """
+        ),
+        test_dep3=(
+            """
+            import pytest
 
-    def test_one():
-        assert True
+            def test_one():
+                assert True
 
-    @pytest.mark.dependency
-    def test_two():
-        assert True
-    """,
-        test_dep4="""
-    import pytest
+            @pytest.mark.dependency
+            def test_two():
+                assert True
+            """
+        ),
+        test_dep4=(
+            """
+            import pytest
 
-    def test_one():
-        assert True
+            def test_one():
+                assert True
 
-    def test_two():
-        assert True
-    """)
+            def test_two():
+                assert True
+            """
+        ),
+    )
     yield test_path
 
 
-@pytest.mark.skipif(pytest.__version__.startswith("3.7."),
-                    reason="pytest-dependency < 0.5 does not support "
-                           "session scope")
+@pytest.mark.skipif(
+    pytest.__version__.startswith("3.7."),
+    reason="pytest-dependency < 0.5 does not support session scope",
+)
 def test_session_scope(fixture_path):
     result = fixture_path.runpytest("-v", "--order-dependencies")
     result.assert_outcomes(passed=11, failed=0)
@@ -85,12 +97,14 @@ def test_session_scope(fixture_path):
     ])
 
 
-@pytest.mark.skipif(pytest.__version__.startswith("3.7."),
-                    reason="pytest-dependency < 0.5 does not support "
-                           "session scope")
+@pytest.mark.skipif(
+    pytest.__version__.startswith("3.7."),
+    reason="pytest-dependency < 0.5 does not support session scope",
+)
 def test_module_group_scope(fixture_path):
-    result = fixture_path.runpytest("-v", "--order-dependencies",
-                                    "--order-group-scope=module")
+    result = fixture_path.runpytest(
+        "-v", "--order-dependencies", "--order-group-scope=module"
+    )
     result.assert_outcomes(passed=11, failed=0)
     result.stdout.fnmatch_lines([
         "test_dep3.py::test_one PASSED",
@@ -107,12 +121,14 @@ def test_module_group_scope(fixture_path):
     ])
 
 
-@pytest.mark.skipif(pytest.__version__.startswith("3.7."),
-                    reason="pytest-dependency < 0.5 does not support "
-                           "session scope")
+@pytest.mark.skipif(
+    pytest.__version__.startswith("3.7."),
+    reason="pytest-dependency < 0.5 does not support session scope",
+)
 def test_class_group_scope(fixture_path):
-    result = fixture_path.runpytest("-v", "--order-dependencies",
-                                    "--order-group-scope=class")
+    result = fixture_path.runpytest(
+        "-v", "--order-dependencies", "--order-group-scope=class"
+    )
     result.assert_outcomes(passed=11, failed=0)
     result.stdout.fnmatch_lines([
         "test_dep3.py::test_one PASSED",
@@ -125,13 +141,14 @@ def test_class_group_scope(fixture_path):
         "test_dep2.py::test_one PASSED",
         "test_dep2.py::test_two PASSED",
         "test_dep4.py::test_one PASSED",
-        "test_dep4.py::test_two PASSED"
+        "test_dep4.py::test_two PASSED",
     ])
 
 
-@pytest.mark.skipif(pytest.__version__.startswith("3.7."),
-                    reason="pytest-dependency < 0.5 does not support "
-                           "session scope")
+@pytest.mark.skipif(
+    pytest.__version__.startswith("3.7."),
+    reason="pytest-dependency < 0.5 does not support session scope",
+)
 def test_class_group_scope_module_scope(fixture_path):
     result = fixture_path.runpytest(
         "-v", "--order-dependencies",
@@ -148,5 +165,5 @@ def test_class_group_scope_module_scope(fixture_path):
         "test_dep3.py::test_one PASSED",
         "test_dep3.py::test_two PASSED",
         "test_dep4.py::test_one PASSED",
-        "test_dep4.py::test_two PASSED"
+        "test_dep4.py::test_two PASSED",
     ])

--- a/tests/test_order_group_scope_named_dep.py
+++ b/tests/test_order_group_scope_named_dep.py
@@ -6,61 +6,76 @@ import pytest
 @pytest.fixture
 def fixture_path(test_path):
     test_path.makepyfile(
-        test_named_dep1="""
-    import pytest
+        test_named_dep1=(
+            """
+            import pytest
 
-    class Test1:
-        @pytest.mark.dependency(depends=['Test2_test2'])
-        def test_one(self):
-            assert True
+            class Test1:
+                @pytest.mark.dependency(depends=['Test2_test2'])
+                def test_one(self):
+                    assert True
 
-        def test_two(self):
-            assert True
+                def test_two(self):
+                    assert True
 
-    class Test2:
-        def test_one(self):
-            assert True
+            class Test2:
+                def test_one(self):
+                    assert True
 
-        @pytest.mark.dependency(name='Test2_test2',
-                                depends=['dep3_test_two'], scope='session')
-        def test_two(self):
-            assert True
-    """,
-        test_named_dep2="""
-    import pytest
+                @pytest.mark.dependency(
+                    name='Test2_test2',
+                    depends=['dep3_test_two'],
+                    scope='session',
+                )
+                def test_two(self):
+                    assert True
+            """
+        ),
+        test_named_dep2=(
+            """
+            import pytest
 
-    @pytest.mark.dependency(depends=['dep3_test_two'], scope='session')
-    def test_one():
-        assert True
+            @pytest.mark.dependency(
+                depends=['dep3_test_two'], scope='session'
+            )
+            def test_one():
+                assert True
 
-    def test_two():
-        assert True
-    """,
-        test_named_dep3="""
-    import pytest
+            def test_two():
+                assert True
+            """
+        ),
+        test_named_dep3=(
+            """
+            import pytest
 
-    def test_one():
-        assert True
+            def test_one():
+                assert True
 
-    @pytest.mark.dependency(name='dep3_test_two')
-    def test_two():
-        assert True
-    """,
-        test_named_dep4="""
-    import pytest
+            @pytest.mark.dependency(name='dep3_test_two')
+            def test_two():
+                assert True
+            """
+        ),
+        test_named_dep4=(
+            """
+            import pytest
 
-    def test_one():
-        assert True
+            def test_one():
+                assert True
 
-    def test_two():
-        assert True
-    """)
+            def test_two():
+                assert True
+            """
+        ),
+    )
     yield test_path
 
 
-@pytest.mark.skipif(pytest.__version__.startswith("3.7."),
-                    reason="pytest-dependency < 0.5 does not support "
-                           "session scope")
+@pytest.mark.skipif(
+    pytest.__version__.startswith("3.7."),
+    reason="pytest-dependency < 0.5 does not support session scope",
+)
 def test_session_scope(fixture_path):
     result = fixture_path.runpytest("-v", "--order-dependencies")
     result.assert_outcomes(passed=10, failed=0)
@@ -78,12 +93,14 @@ def test_session_scope(fixture_path):
     ])
 
 
-@pytest.mark.skipif(pytest.__version__.startswith("3.7."),
-                    reason="pytest-dependency < 0.5 does not support "
-                           "session scope")
+@pytest.mark.skipif(
+    pytest.__version__.startswith("3.7."),
+    reason="pytest-dependency < 0.5 does not support session scope",
+)
 def test_module_group_scope(fixture_path):
-    result = fixture_path.runpytest("-v", "--order-dependencies",
-                                    "--order-group-scope=module")
+    result = fixture_path.runpytest(
+        "-v", "--order-dependencies", "--order-group-scope=module"
+    )
     result.assert_outcomes(passed=10, failed=0)
     result.stdout.fnmatch_lines([
         "test_named_dep3.py::test_one PASSED",
@@ -95,16 +112,18 @@ def test_module_group_scope(fixture_path):
         "test_named_dep2.py::test_one PASSED",
         "test_named_dep2.py::test_two PASSED",
         "test_named_dep4.py::test_one PASSED",
-        "test_named_dep4.py::test_two PASSED"
+        "test_named_dep4.py::test_two PASSED",
     ])
 
 
-@pytest.mark.skipif(pytest.__version__.startswith("3.7."),
-                    reason="pytest-dependency < 0.5 does not support "
-                           "session scope")
+@pytest.mark.skipif(
+    pytest.__version__.startswith("3.7."),
+    reason="pytest-dependency < 0.5 does not support session scope",
+)
 def test_class_group_scope(fixture_path):
-    result = fixture_path.runpytest("-v", "--order-dependencies",
-                                    "--order-group-scope=class")
+    result = fixture_path.runpytest(
+        "-v", "--order-dependencies", "--order-group-scope=class"
+    )
     result.assert_outcomes(passed=10, failed=0)
     result.stdout.fnmatch_lines([
         "test_named_dep3.py::test_one PASSED",
@@ -120,13 +139,17 @@ def test_class_group_scope(fixture_path):
     ])
 
 
-@pytest.mark.skipif(pytest.__version__.startswith("3.7."),
-                    reason="pytest-dependency < 0.5 does not support "
-                           "session scope")
+@pytest.mark.skipif(
+    pytest.__version__.startswith("3.7."),
+    reason="pytest-dependency < 0.5 does not support session scope",
+)
 def test_class_group_scope_module_scope(fixture_path):
     result = fixture_path.runpytest(
-        "-v", "--order-dependencies",
-        "--order-group-scope=class", "--order-scope=module")
+        "-v",
+        "--order-dependencies",
+        "--order-group-scope=class",
+        "--order-scope=module",
+    )
     result.assert_outcomes(passed=7, skipped=3)
     result.stdout.fnmatch_lines([
         "test_named_dep1.py::Test2::test_one PASSED",

--- a/tests/test_order_group_scope_relative.py
+++ b/tests/test_order_group_scope_relative.py
@@ -6,53 +6,61 @@ import pytest
 @pytest.fixture
 def fixture_path(test_path):
     test_path.makepyfile(
-        test_rel1="""
-    import pytest
+        test_rel1=(
+            """
+            import pytest
 
-    class Test1:
-        @pytest.mark.order(after='Test2::test_two')
-        def test_one(self):
-            assert True
+            class Test1:
+                @pytest.mark.order(after='Test2::test_two')
+                def test_one(self):
+                    assert True
 
-        def test_two(self):
-            assert True
+                def test_two(self):
+                    assert True
 
-    class Test2:
-        @pytest.mark.order(after='invalid')
-        def test_one(self):
-            assert True
+            class Test2:
+                @pytest.mark.order(after='invalid')
+                def test_one(self):
+                    assert True
 
-        @pytest.mark.order(after='test_rel3.py::test_two')
-        def test_two(self):
-            assert True
-    """,
-        test_rel2="""
-    def test_one():
-        assert True
+                @pytest.mark.order(after='test_rel3.py::test_two')
+                def test_two(self):
+                    assert True
+            """
+        ),
+        test_rel2=(
+            """
+            def test_one():
+                assert True
 
-    def test_two():
-        assert True
-    """,
-        test_rel3="""
-    import pytest
+            def test_two():
+                assert True
+            """
+        ),
+        test_rel3=(
+            """
+            import pytest
 
-    def test_one():
-        assert True
+            def test_one():
+                assert True
 
-    @pytest.mark.order(before='test_rel2.py::test_one')
-    def test_two():
-        assert True
-    """,
-        test_rel4="""
-    import pytest
+            @pytest.mark.order(before='test_rel2.py::test_one')
+            def test_two():
+                assert True
+            """
+        ),
+        test_rel4=(
+            """
+            import pytest
 
-    def test_one():
-        assert True
+            def test_one():
+                assert True
 
-    def test_two():
-        assert True
-    """)
-
+            def test_two():
+                assert True
+            """
+        ),
+    )
     yield test_path
 
 
@@ -87,7 +95,7 @@ def test_module_group_scope(fixture_path):
         "test_rel2.py::test_one PASSED",
         "test_rel2.py::test_two PASSED",
         "test_rel4.py::test_one PASSED",
-        "test_rel4.py::test_two PASSED"
+        "test_rel4.py::test_two PASSED",
     ])
 
 
@@ -104,13 +112,14 @@ def test_class_group_scope(fixture_path):
         "test_rel2.py::test_one PASSED",
         "test_rel2.py::test_two PASSED",
         "test_rel4.py::test_one PASSED",
-        "test_rel4.py::test_two PASSED"
+        "test_rel4.py::test_two PASSED",
     ])
 
 
 def test_class_group_scope_module_scope(fixture_path):
-    result = fixture_path.runpytest("-v", "--order-group-scope=class",
-                                    "--order-scope=module")
+    result = fixture_path.runpytest(
+        "-v", "--order-group-scope=class", "--order-scope=module"
+    )
     result.assert_outcomes(passed=10, failed=0)
     result.stdout.fnmatch_lines([
         "test_rel1.py::Test2::test_one PASSED",
@@ -122,5 +131,5 @@ def test_class_group_scope_module_scope(fixture_path):
         "test_rel3.py::test_one PASSED",
         "test_rel3.py::test_two PASSED",
         "test_rel4.py::test_one PASSED",
-        "test_rel4.py::test_two PASSED"
+        "test_rel4.py::test_two PASSED",
     ])

--- a/tests/test_order_scope.py
+++ b/tests/test_order_scope.py
@@ -6,57 +6,64 @@ import pytest
 @pytest.fixture
 def fixture_path(test_path):
     test_path.makepyfile(
-        test_classes="""
-    import pytest
+        test_classes=(
+            """
+            import pytest
 
-    class Test1:
-        @pytest.mark.order("last")
-        def test_two(self):
-            assert True
+            class Test1:
+                @pytest.mark.order("last")
+                def test_two(self):
+                    assert True
 
-        @pytest.mark.order("first")
-        def test_one(self):
-            assert True
+                @pytest.mark.order("first")
+                def test_one(self):
+                    assert True
 
-    class Test2:
-        @pytest.mark.order("last")
-        def test_two(self):
-            assert True
+            class Test2:
+                @pytest.mark.order("last")
+                def test_two(self):
+                    assert True
 
-        @pytest.mark.order("first")
-        def test_one(self):
-            assert True
+                @pytest.mark.order("first")
+                def test_one(self):
+                    assert True
 
-    @pytest.mark.order("last")
-    def test_two():
-        assert True
+            @pytest.mark.order("last")
+            def test_two():
+                assert True
 
-    @pytest.mark.order("first")
-    def test_one():
-        assert True
-    """,
-        test_functions1="""
-    import pytest
+            @pytest.mark.order("first")
+            def test_one():
+                assert True
+            """
+        ),
+        test_functions1=(
+            """
+            import pytest
 
-    @pytest.mark.order("last")
-    def test1_two():
-        assert True
+            @pytest.mark.order("last")
+            def test1_two():
+                assert True
 
-    @pytest.mark.order("first")
-    def test1_one():
-        assert True
-    """,
-        test_functions2="""
-    import pytest
+            @pytest.mark.order("first")
+            def test1_one():
+                assert True
+            """
+        ),
+        test_functions2=(
+            """
+            import pytest
 
-    @pytest.mark.order("last")
-    def test2_two():
-        assert True
+            @pytest.mark.order("last")
+            def test2_two():
+                assert True
 
-    @pytest.mark.order("first")
-    def test2_one():
-        assert True
-    """)
+            @pytest.mark.order("first")
+            def test2_one():
+                assert True
+            """
+        ),
+    )
     yield test_path
 
 
@@ -73,7 +80,7 @@ def test_session_scope(fixture_path):
         "test_classes.py::Test2::test_two PASSED",
         "test_classes.py::test_two PASSED",
         "test_functions1.py::test1_two PASSED",
-        "test_functions2.py::test2_two PASSED"
+        "test_functions2.py::test2_two PASSED",
     ])
 
 
@@ -90,7 +97,7 @@ def test_module_scope(fixture_path):
         "test_functions1.py::test1_one PASSED",
         "test_functions1.py::test1_two PASSED",
         "test_functions2.py::test2_one PASSED",
-        "test_functions2.py::test2_two PASSED"
+        "test_functions2.py::test2_two PASSED",
     ])
 
 
@@ -107,12 +114,14 @@ def test_class_scope(fixture_path):
         "test_functions1.py::test1_one PASSED",
         "test_functions1.py::test1_two PASSED",
         "test_functions2.py::test2_one PASSED",
-        "test_functions2.py::test2_two PASSED"
+        "test_functions2.py::test2_two PASSED",
     ])
 
 
-@pytest.mark.skipif(pytest.__version__.startswith("3.7."),
-                    reason="Warning does not appear in output in pytest < 3.8")
+@pytest.mark.skipif(
+    pytest.__version__.startswith("3.7."),
+    reason="Warning does not appear in output in pytest < 3.8",
+)
 def test_invalid_scope(fixture_path):
     result = fixture_path.runpytest("-v", "--order-scope=function")
     result.assert_outcomes(passed=10, failed=0)

--- a/tests/test_order_scope_level.py
+++ b/tests/test_order_scope_level.py
@@ -1,28 +1,33 @@
 # -*- coding: utf-8 -*-
+from textwrap import dedent
 
 import pytest
 
 
 @pytest.fixture
 def fixture_path(test_path):
-    test_a_contents = """
-import pytest
+    test_a_contents = dedent(
+        """
+        import pytest
 
-@pytest.mark.order(4)
-def test_four(): pass
+        @pytest.mark.order(4)
+        def test_four(): pass
 
-@pytest.mark.order(3)
-def test_three(): pass
-    """
-    test_b_contents = """
-import pytest
+        @pytest.mark.order(3)
+        def test_three(): pass
+        """
+    )
+    test_b_contents = dedent(
+        """
+        import pytest
 
-@pytest.mark.order(2)
-def test_two(): pass
+        @pytest.mark.order(2)
+        def test_two(): pass
 
-@pytest.mark.order(1)
-def test_one(): pass
-"""
+        @pytest.mark.order(1)
+        def test_one(): pass
+        """
+    )
     for i in range(3):
         sub_path = "feature{}".format(i)
         test_path.mkpydir(sub_path)
@@ -48,7 +53,7 @@ def test_session_scope(fixture_path):
         "feature2/test_a.py::test_three PASSED",
         "feature0/test_a.py::test_four PASSED",
         "feature1/test_a.py::test_four PASSED",
-        "feature2/test_a.py::test_four PASSED"
+        "feature2/test_a.py::test_four PASSED",
     ])
 
 
@@ -88,7 +93,7 @@ def test_dir_level1(fixture_path, capsys):
         "feature2/test_b.py::test_one PASSED",
         "feature2/test_b.py::test_two PASSED",
         "feature2/test_a.py::test_three PASSED",
-        "feature2/test_a.py::test_four PASSED"
+        "feature2/test_a.py::test_four PASSED",
     ])
 
 
@@ -108,16 +113,20 @@ def test_dir_level2(fixture_path, capsys):
         "feature2/test_a.py::test_three PASSED",
         "feature2/test_a.py::test_four PASSED",
         "feature2/test_b.py::test_one PASSED",
-        "feature2/test_b.py::test_two PASSED"
+        "feature2/test_b.py::test_two PASSED",
     ])
 
 
-@pytest.mark.skipif(pytest.__version__.startswith("3.7."),
-                    reason="Warning does not appear in output in pytest < 3.8")
+@pytest.mark.skipif(
+    pytest.__version__.startswith("3.7."),
+    reason="Warning does not appear in output in pytest < 3.8",
+)
 def test_invalid_scope(fixture_path):
-    result = fixture_path.runpytest("-v", "--order-scope=module",
-                                    "--order-scope-level=1")
+    result = fixture_path.runpytest(
+        "-v", "--order-scope=module", "--order-scope-level=1"
+    )
     result.assert_outcomes(passed=12, failed=0)
     result.stdout.fnmatch_lines([
         "*UserWarning: order-scope-level cannot be used "
-        "together with --order-scope=module*"])
+        "together with --order-scope=module*"
+    ])

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -340,7 +340,9 @@ def test_sparse_numbers(item_names_for):
             assert True
         """
     )
-    assert item_names_for(test_content) == ["test_one", "test_two", "test_three"]
+    assert item_names_for(test_content) == [
+        "test_one", "test_two", "test_three"
+    ]
 
 
 def test_quickstart(item_names_for):

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -4,358 +4,389 @@ import pytest
 
 
 def test_no_marks(item_names_for):
-    tests_content = """
-    def test_1(): pass
+    tests_content = (
+        """
+        def test_1(): pass
 
-    def test_2(): pass
-    """
-
+        def test_2(): pass
+        """
+    )
     assert item_names_for(tests_content) == ["test_1", "test_2"]
 
 
 def test_first_mark(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    def test_1(): pass
+        def test_1(): pass
 
-    @pytest.mark.order("first")
-    def test_2(): pass
-    """
-
+        @pytest.mark.order("first")
+        def test_2(): pass
+        """
+    )
     assert item_names_for(tests_content) == ["test_2", "test_1"]
 
 
 def test_last_mark(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order("last")
-    def test_1(): pass
+        @pytest.mark.order("last")
+        def test_1(): pass
 
-    def test_2(): pass
-    """
-
+        def test_2(): pass
+        """
+    )
     assert item_names_for(tests_content) == ["test_2", "test_1"]
 
 
 def test_first_last_marks(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order("last")
-    def test_1(): pass
+        @pytest.mark.order("last")
+        def test_1(): pass
 
-    @pytest.mark.order("first")
-    def test_2(): pass
+        @pytest.mark.order("first")
+        def test_2(): pass
 
-    def test_3(): pass
-    """
-
+        def test_3(): pass
+        """
+    )
     assert item_names_for(tests_content) == ["test_2", "test_3", "test_1"]
 
 
 def test_order_marks(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(-1)
-    def test_1(): pass
+        @pytest.mark.order(-1)
+        def test_1(): pass
 
-    @pytest.mark.order(-2)
-    def test_2(): pass
+        @pytest.mark.order(-2)
+        def test_2(): pass
 
-    @pytest.mark.order(1)
-    def test_3(): pass
-    """
-
+        @pytest.mark.order(1)
+        def test_3(): pass
+        """
+    )
     assert item_names_for(tests_content) == ["test_3", "test_2", "test_1"]
 
 
 def test_order_marks_by_index(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(index=-1)
-    def test_1(): pass
+        @pytest.mark.order(index=-1)
+        def test_1(): pass
 
-    @pytest.mark.order(index=-2)
-    def test_2(): pass
+        @pytest.mark.order(index=-2)
+        def test_2(): pass
 
-    @pytest.mark.order(index=1)
-    def test_3(): pass
-    """
-
+        @pytest.mark.order(index=1)
+        def test_3(): pass
+        """
+    )
     assert item_names_for(tests_content) == ["test_3", "test_2", "test_1"]
 
 
 def test_non_contiguous_positive(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(10)
-    def test_1(): pass
+        @pytest.mark.order(10)
+        def test_1(): pass
 
-    @pytest.mark.order(20)
-    def test_2(): pass
+        @pytest.mark.order(20)
+        def test_2(): pass
 
-    @pytest.mark.order(5)
-    def test_3(): pass
-    """
-
+        @pytest.mark.order(5)
+        def test_3(): pass
+        """
+    )
     assert item_names_for(tests_content) == ["test_3", "test_1", "test_2"]
 
 
 def test_non_contiguous_negative(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(-10)
-    def test_1(): pass
+        @pytest.mark.order(-10)
+        def test_1(): pass
 
-    @pytest.mark.order(-20)
-    def test_2(): pass
+        @pytest.mark.order(-20)
+        def test_2(): pass
 
-    @pytest.mark.order(-5)
-    def test_3(): pass
-    """
-
+        @pytest.mark.order(-5)
+        def test_3(): pass
+        """
+    )
     assert item_names_for(tests_content) == ["test_2", "test_1", "test_3"]
 
 
 def test_non_contiguous_inc_zero(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(10)
-    def test_1(): pass
+        @pytest.mark.order(10)
+        def test_1(): pass
 
-    @pytest.mark.order(20)
-    def test_2(): pass
+        @pytest.mark.order(20)
+        def test_2(): pass
 
-    @pytest.mark.order(5)
-    def test_3(): pass
+        @pytest.mark.order(5)
+        def test_3(): pass
 
-    @pytest.mark.order(-10)
-    def test_4(): pass
+        @pytest.mark.order(-10)
+        def test_4(): pass
 
-    @pytest.mark.order(-20)
-    def test_5(): pass
+        @pytest.mark.order(-20)
+        def test_5(): pass
 
-    @pytest.mark.order(-5)
-    def test_6(): pass
+        @pytest.mark.order(-5)
+        def test_6(): pass
 
-    @pytest.mark.order(0)
-    def test_7(): pass
-    """
-
-    assert item_names_for(tests_content) == ["test_7", "test_3", "test_1",
-                                             "test_2", "test_5", "test_4",
-                                             "test_6"]
+        @pytest.mark.order(0)
+        def test_7(): pass
+        """
+    )
+    assert item_names_for(tests_content) == [
+        "test_7", "test_3", "test_1", "test_2", "test_5", "test_4", "test_6"
+    ]
 
 
 def test_non_contiguous_inc_none(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(5)
-    def test_1(): pass
+        @pytest.mark.order(5)
+        def test_1(): pass
 
-    @pytest.mark.order(0)
-    def test_2(): pass
+        @pytest.mark.order(0)
+        def test_2(): pass
 
-    @pytest.mark.order(1)
-    def test_3(): pass
+        @pytest.mark.order(1)
+        def test_3(): pass
 
-    @pytest.mark.order(-1)
-    def test_4(): pass
+        @pytest.mark.order(-1)
+        def test_4(): pass
 
-    @pytest.mark.order(-5)
-    def test_5(): pass
+        @pytest.mark.order(-5)
+        def test_5(): pass
 
-    def test_6(): pass
-    """
-
-    assert item_names_for(tests_content) == ["test_2", "test_3", "test_1",
-                                             "test_6", "test_5", "test_4"]
+        def test_6(): pass
+        """
+    )
+    assert item_names_for(tests_content) == [
+        "test_2", "test_3", "test_1", "test_6", "test_5", "test_4"
+    ]
 
 
 def test_first_mark_class(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    def test_1(): pass
+        def test_1(): pass
 
 
-    @pytest.mark.order("first")
-    class TestSuite:
+        @pytest.mark.order("first")
+        class TestSuite:
 
-        def test_3(self): pass
+            def test_3(self): pass
 
-        def test_2(self): pass
+            def test_2(self): pass
 
-    """
-
+        """
+    )
     assert item_names_for(tests_content) == [
         "TestSuite::test_3", "TestSuite::test_2", "test_1"
     ]
 
 
 def test_last_mark_class(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order("last")
-    class TestSuite:
+        @pytest.mark.order("last")
+        class TestSuite:
 
-        def test_1(self): pass
+            def test_1(self): pass
 
-        def test_2(self): pass
+            def test_2(self): pass
 
 
-    def test_3(): pass
-    """
-
+        def test_3(): pass
+        """
+    )
     assert item_names_for(tests_content) == [
         "test_3", "TestSuite::test_1", "TestSuite::test_2"
     ]
 
 
 def test_first_last_mark_class(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order("last")
-    class TestLast:
+        @pytest.mark.order("last")
+        class TestLast:
 
-        def test_1(self): pass
+            def test_1(self): pass
 
-        def test_2(self): pass
-
-
-    def test_0(): pass
+            def test_2(self): pass
 
 
-    @pytest.mark.order("first")
-    class TestFirst:
+        def test_0(): pass
 
-        def test_1(self): pass
 
-        def test_2(self): pass
+        @pytest.mark.order("first")
+        class TestFirst:
 
-    """
+            def test_1(self): pass
 
+            def test_2(self): pass
+
+        """
+    )
     assert item_names_for(tests_content) == [
-        "TestFirst::test_1", "TestFirst::test_2",
-        "test_0", "TestLast::test_1", "TestLast::test_2"]
+        "TestFirst::test_1",
+        "TestFirst::test_2",
+        "test_0",
+        "TestLast::test_1",
+        "TestLast::test_2",
+    ]
 
 
 def test_order_mark_class(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(-1)
-    class TestLast:
-        def test_1(self): pass
-        def test_2(self): pass
+        @pytest.mark.order(-1)
+        class TestLast:
+            def test_1(self): pass
+            def test_2(self): pass
 
-    @pytest.mark.order(0)
-    def test_0(): pass
+        @pytest.mark.order(0)
+        def test_0(): pass
 
-    @pytest.mark.order(-2)
-    class TestFirst:
-        def test_1(self): pass
-        def test_2(self): pass
-    """
-
+        @pytest.mark.order(-2)
+        class TestFirst:
+            def test_1(self): pass
+            def test_2(self): pass
+        """
+    )
     assert item_names_for(tests_content) == [
-        "test_0", "TestFirst::test_1", "TestFirst::test_2",
-        "TestLast::test_1", "TestLast::test_2"
+        "test_0",
+        "TestFirst::test_1",
+        "TestFirst::test_2",
+        "TestLast::test_1",
+        "TestLast::test_2",
     ]
 
 
 def test_run_ordinals(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    @pytest.mark.order("second_to_last")
-    def test_three():
-        pass
+        @pytest.mark.order("second_to_last")
+        def test_three():
+            pass
 
-    @pytest.mark.order("last")
-    def test_four():
-        pass
+        @pytest.mark.order("last")
+        def test_four():
+            pass
 
-    @pytest.mark.order("second")
-    def test_two():
-        pass
+        @pytest.mark.order("second")
+        def test_two():
+            pass
 
-    @pytest.mark.order("first")
-    def test_one():
-        pass
-    """
-
-    assert item_names_for(test_content) == ["test_one", "test_two",
-                                            "test_three", "test_four"]
+        @pytest.mark.order("first")
+        def test_one():
+            pass
+        """
+    )
+    assert item_names_for(test_content) == [
+        "test_one", "test_two", "test_three", "test_four"
+    ]
 
 
 def test_sparse_numbers(item_names_for):
-    test_content = """
-     import pytest
+    test_content = (
+        """
+        import pytest
 
-     @pytest.mark.order(4)
-     def test_two():
-         assert True
+        @pytest.mark.order(4)
+        def test_two():
+            assert True
 
-     def test_three():
-         assert True
+        def test_three():
+            assert True
 
-     @pytest.mark.order(2)
-     def test_one():
-         assert True
-    """
-    assert item_names_for(test_content) == ["test_one", "test_two",
-                                            "test_three"]
+        @pytest.mark.order(2)
+        def test_one():
+            assert True
+        """
+    )
+    assert item_names_for(test_content) == ["test_one", "test_two", "test_three"]
 
 
 def test_quickstart(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    def test_foo():
-        pass
+        def test_foo():
+            pass
 
-    def test_bar():
-        pass
-    """
+        def test_bar():
+            pass
+        """
+    )
     assert item_names_for(test_content) == ["test_foo", "test_bar"]
 
 
 def test_quickstart2(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(2)
-    def test_foo():
-        pass
+        @pytest.mark.order(2)
+        def test_foo():
+            pass
 
-    @pytest.mark.order(1)
-    def test_bar():
-        pass
-    """
+        @pytest.mark.order(1)
+        def test_bar():
+            pass
+        """
+    )
     assert item_names_for(test_content) == ["test_bar", "test_foo"]
 
 
 def test_unsupported_order(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    @pytest.mark.order("unknown")
-    def test_1():
-        pass
+        @pytest.mark.order("unknown")
+        def test_1():
+            pass
 
-    def test_2():
-        pass
-    """
+        def test_2():
+            pass
+        """
+    )
     with pytest.warns(UserWarning, match="Unknown order attribute:'unknown'"):
         assert item_names_for(test_content) == ["test_1", "test_2"]

--- a/tests/test_relative_ordering.py
+++ b/tests/test_relative_ordering.py
@@ -1,183 +1,204 @@
 # -*- coding: utf-8 -*-
+from textwrap import dedent
 
 import pytest
 
 
 def test_relative(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(after="test_second")
-    def test_third():
-        pass
+        @pytest.mark.order(after="test_second")
+        def test_third():
+            pass
 
-    def test_second():
-        pass
+        def test_second():
+            pass
 
-    @pytest.mark.order(before="test_second")
-    def test_first():
-        pass
-    """
-    assert item_names_for(test_content) == ["test_first", "test_second",
-                                            "test_third"]
+        @pytest.mark.order(before="test_second")
+        def test_first():
+            pass
+        """
+    )
+    assert item_names_for(test_content) == [
+        "test_first", "test_second", "test_third"
+    ]
 
 
 def test_relative2(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(after="test_second")
-    def test_third():
-        pass
+        @pytest.mark.order(after="test_second")
+        def test_third():
+            pass
 
-    def test_second():
-        pass
+        def test_second():
+            pass
 
-    @pytest.mark.order(before="test_second")
-    def test_first():
-        pass
+        @pytest.mark.order(before="test_second")
+        def test_first():
+            pass
 
-    def test_five():
-        pass
+        def test_five():
+            pass
 
-    @pytest.mark.order(before="test_five")
-    def test_four():
-        pass
-
-    """
-    assert item_names_for(test_content) == ["test_first", "test_second",
-                                            "test_third", "test_four",
-                                            "test_five"]
+        @pytest.mark.order(before="test_five")
+        def test_four():
+            pass
+        """
+    )
+    assert item_names_for(test_content) == [
+        "test_first", "test_second", "test_third", "test_four", "test_five"
+    ]
 
 
 def test_relative3(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(after="test_second")
-    def test_third():
-        pass
+        @pytest.mark.order(after="test_second")
+        def test_third():
+            pass
 
-    def test_second():
-        pass
+        def test_second():
+            pass
 
-    @pytest.mark.order(before="test_second")
-    def test_first():
-        pass
+        @pytest.mark.order(before="test_second")
+        def test_first():
+            pass
 
-    def test_five():
-        pass
+        def test_five():
+            pass
 
-    @pytest.mark.order(before="test_five")
-    def test_four():
-        pass
-
-    """
-    assert item_names_for(test_content) == ["test_first", "test_second",
-                                            "test_third", "test_four",
-                                            "test_five"]
+        @pytest.mark.order(before="test_five")
+        def test_four():
+            pass
+        """
+    )
+    assert item_names_for(test_content) == [
+        "test_first", "test_second", "test_third", "test_four", "test_five"
+    ]
 
 
 def test_relative_in_class(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    class Test:
-        @pytest.mark.order(after="test_b")
-        def test_a(self):
-            pass
+        class Test:
+            @pytest.mark.order(after="test_b")
+            def test_a(self):
+                pass
 
-        def test_b(self):
-            pass
+            def test_b(self):
+                pass
 
-        def test_c(self):
-            pass
-    """
+            def test_c(self):
+                pass
+        """
+    )
     assert item_names_for(tests_content) == [
         "Test::test_b", "Test::test_a", "Test::test_c"
     ]
 
 
 def test_relative_in_classes(item_names_for):
-    tests_content = """
-    import pytest
+    tests_content = (
+        """
+        import pytest
 
-    class TestA:
-        @pytest.mark.order(after="TestB::test_b")
-        def test_a(self):
-            pass
+        class TestA:
+            @pytest.mark.order(after="TestB::test_b")
+            def test_a(self):
+                pass
 
-        @pytest.mark.order(after="test_c")
-        def test_b(self):
-            pass
+            @pytest.mark.order(after="test_c")
+            def test_b(self):
+                pass
 
-        def test_c(self):
-            pass
+            def test_c(self):
+                pass
 
-    class TestB:
-        @pytest.mark.order(before="TestA::test_c")
-        def test_a(self):
-            pass
+        class TestB:
+            @pytest.mark.order(before="TestA::test_c")
+            def test_a(self):
+                pass
 
-        def test_b(self):
-            pass
+            def test_b(self):
+                pass
 
-        def test_c(self):
-            pass
-    """
+            def test_c(self):
+                pass
+        """
+    )
     assert item_names_for(tests_content) == [
-        "TestB::test_a", "TestA::test_c", "TestA::test_b",
-        "TestB::test_b", "TestA::test_a", "TestB::test_c"
+        "TestB::test_a",
+        "TestA::test_c",
+        "TestA::test_b",
+        "TestB::test_b",
+        "TestA::test_a",
+        "TestB::test_c",
     ]
 
 
 @pytest.fixture
 def fixture_path(test_path):
     test_path.makepyfile(
-        mod1_test="""
-    import pytest
+        mod1_test=(
+            """
+            import pytest
 
-    class TestA:
-        @pytest.mark.order(after="mod2_test.py::TestB::test_b")
-        def test_a(self):
-            pass
+            class TestA:
+                @pytest.mark.order(after="mod2_test.py::TestB::test_b")
+                def test_a(self):
+                    pass
 
-        @pytest.mark.order(after="sub/mod3_test.py::test_b")
-        def test_b(self):
-            pass
+                @pytest.mark.order(after="sub/mod3_test.py::test_b")
+                def test_b(self):
+                    pass
 
-        def test_c(self):
-            pass
-    """,
-        mod2_test="""
-    import pytest
+                def test_c(self):
+                    pass
+            """
+        ),
+        mod2_test=(
+            """
+            import pytest
 
-    class TestB:
-        @pytest.mark.order(before="mod1_test.py::TestA::test_c")
-        def test_a(self):
-            pass
+            class TestB:
+                @pytest.mark.order(before="mod1_test.py::TestA::test_c")
+                def test_a(self):
+                    pass
 
-        def test_b(self):
-            pass
+                def test_b(self):
+                    pass
 
-        def test_c(self):
-            pass
-    """)
+                def test_c(self):
+                    pass
+            """
+        ),
+    )
     test_path.mkpydir("sub")
     path = test_path.tmpdir.join("sub", "mod3_test.py")
-    path.write("""
-import pytest
+    path.write(dedent(
+        """
+        import pytest
 
-@pytest.mark.order(before="mod2_test.py::TestB::test_c")
-def test_a():
-    pass
+        @pytest.mark.order(before="mod2_test.py::TestB::test_c")
+        def test_a():
+            pass
 
-def test_b():
-    pass
+        def test_b():
+            pass
 
-def test_c():
-    pass
-    """)
+        def test_c():
+            pass
+        """
+    ))
     yield test_path
 
 
@@ -193,246 +214,279 @@ def test_relative_in_modules(fixture_path):
         "mod2_test.py::TestB::test_c PASSED",
         "sub/mod3_test.py::test_b PASSED",
         "mod1_test.py::TestA::test_b PASSED",
-        "sub/mod3_test.py::test_c PASSED"
+        "sub/mod3_test.py::test_c PASSED",
     ])
 
 
 def test_false_insert(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(after="test_a")
-    def test_third():
-        pass
+        @pytest.mark.order(after="test_a")
+        def test_third():
+            pass
 
-    def test_second():
-        pass
+        def test_second():
+            pass
 
-    @pytest.mark.order(before="test_b")
-    def test_first():
-        pass
-    """
-    assert item_names_for(test_content) == ["test_third", "test_second",
-                                            "test_first"]
+        @pytest.mark.order(before="test_b")
+        def test_first():
+            pass
+        """
+    )
+    assert item_names_for(test_content) == [
+        "test_third", "test_second", "test_first"
+    ]
 
 
 def test_mixed_markers1(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(2)
-    def test_1():
-        pass
+        @pytest.mark.order(2)
+        def test_1():
+            pass
 
-    @pytest.mark.order(after="test_1")
-    def test_2():
-        pass
+        @pytest.mark.order(after="test_1")
+        def test_2():
+            pass
 
-    @pytest.mark.order(1)
-    def test_3():
-        pass
-    """
+        @pytest.mark.order(1)
+        def test_3():
+            pass
+        """
+    )
     assert item_names_for(test_content) == ["test_3", "test_1", "test_2"]
 
 
 def test_mixed_markers2(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(2)
-    def test_1():
-        pass
+        @pytest.mark.order(2)
+        def test_1():
+            pass
 
-    @pytest.mark.order(1)
-    def test_2():
-        pass
+        @pytest.mark.order(1)
+        def test_2():
+            pass
 
-    @pytest.mark.order(before="test_2")
-    def test_3():
-        pass
-    """
+        @pytest.mark.order(before="test_2")
+        def test_3():
+            pass
+        """
+    )
     assert item_names_for(test_content) == ["test_3", "test_2", "test_1"]
 
 
 def test_combined_markers1(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(2)
-    def test_1():
-        pass
+        @pytest.mark.order(2)
+        def test_1():
+            pass
 
-    def test_2():
-        pass
+        def test_2():
+            pass
 
-    @pytest.mark.order(index=1, before="test_2")
-    def test_3():
-        pass
-    """
+        @pytest.mark.order(index=1, before="test_2")
+        def test_3():
+            pass
+        """
+    )
     assert item_names_for(test_content) == ["test_3", "test_1", "test_2"]
 
 
 def test_combined_markers2(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    def test_1():
-        pass
+        def test_1():
+            pass
 
-    @pytest.mark.order(index=2, before="test_1")
-    def test_2():
-        pass
+        @pytest.mark.order(index=2, before="test_1")
+        def test_2():
+            pass
 
-    @pytest.mark.order(index=1, before="test_1")
-    def test_3():
-        pass
-    """
+        @pytest.mark.order(index=1, before="test_1")
+        def test_3():
+            pass
+        """
+    )
     assert item_names_for(test_content) == ["test_3", "test_2", "test_1"]
 
 
 def test_combined_markers3(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    def test_1():
-        pass
+        def test_1():
+            pass
 
-    @pytest.mark.order(index=2, before="test_3")
-    def test_2():
-        pass
+        @pytest.mark.order(index=2, before="test_3")
+        def test_2():
+            pass
 
-    @pytest.mark.order(index=1, before="test_1")
-    def test_3():
-        pass
-    """
+        @pytest.mark.order(index=1, before="test_1")
+        def test_3():
+            pass
+        """
+    )
     assert item_names_for(test_content) == ["test_2", "test_3", "test_1"]
 
 
 def test_mixed_markers4(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(2)
-    def test_1():
-        pass
+        @pytest.mark.order(2)
+        def test_1():
+            pass
 
-    @pytest.mark.order(index=1, after="test_3")
-    def test_2():
-        pass
+        @pytest.mark.order(index=1, after="test_3")
+        def test_2():
+            pass
 
-    def test_3():
-        pass
-    """
+        def test_3():
+            pass
+        """
+    )
     assert item_names_for(test_content) == ["test_3", "test_2", "test_1"]
 
 
 def test_multiple_markers_in_same_test(item_names_for):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(after=["test_3", "test_4", "test_5"])
-    def test_1():
-        pass
+        @pytest.mark.order(after=["test_3", "test_4", "test_5"])
+        def test_1():
+            pass
 
-    def test_2():
-        pass
+        def test_2():
+            pass
 
-    def test_3():
-        pass
+        def test_3():
+            pass
 
-    @pytest.mark.order(before=["test_3", "test_2"])
-    def test_4():
-        pass
+        @pytest.mark.order(before=["test_3", "test_2"])
+        def test_4():
+            pass
 
-    def test_5():
-        pass
-    """
+        def test_5():
+            pass
+        """
+    )
     assert item_names_for(test_content) == [
         "test_4", "test_2", "test_3", "test_5", "test_1"
     ]
 
 
 def test_dependency_after_unknown_test(item_names_for, capsys):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(after="some_module.py::test_2")
-    def test_1():
-        pass
+        @pytest.mark.order(after="some_module.py::test_2")
+        def test_1():
+            pass
 
-    def test_2():
-        pass
-    """
+        def test_2():
+            pass
+        """
+    )
     assert item_names_for(test_content) == ["test_1", "test_2"]
     out, err = capsys.readouterr()
-    warning = ("cannot execute 'test_1' relative to others: "
-               "'some_module.py::test_2' - ignoring the marker")
+    warning = (
+        "cannot execute 'test_1' relative to others: 'some_module.py::test_2' "
+        "- ignoring the marker"
+    )
     assert warning in out
 
 
 def test_dependency_before_unknown_test(item_names_for, capsys):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    def test_1():
-        pass
+        def test_1():
+            pass
 
-    @pytest.mark.order(before="test_4")
-    def test_2():
-        pass
+        @pytest.mark.order(before="test_4")
+        def test_2():
+            pass
 
-    def test_3():
-        pass
-    """
+        def test_3():
+            pass
+        """
+    )
     assert item_names_for(test_content) == ["test_1", "test_2", "test_3"]
     out, err = capsys.readouterr()
-    warning = ("cannot execute 'test_2' relative to others: "
-               "'test_4' - ignoring the marker")
+    warning = (
+        "cannot execute 'test_2' relative to others: 'test_4' "
+        "- ignoring the marker"
+    )
     assert warning in out
 
 
 def test_dependency_in_class_before_unknown_test(item_names_for, capsys):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    class Test:
-        def test_1(self):
-            pass
+        class Test:
+            def test_1(self):
+                pass
 
-        @pytest.mark.order(before="test_4")
-        def test_2(self):
-            pass
+            @pytest.mark.order(before="test_4")
+            def test_2(self):
+                pass
 
-        def test_3(self):
-            pass
-    """
+            def test_3(self):
+                pass
+        """
+    )
     assert item_names_for(test_content) == [
         "Test::test_1", "Test::test_2", "Test::test_3"
     ]
     out, err = capsys.readouterr()
-    warning = ("cannot execute 'test_2' relative to others: "
-               "'test_4' - ignoring the marker")
+    warning = (
+        "cannot execute 'test_2' relative to others: 'test_4' "
+        "- ignoring the marker"
+    )
     assert warning in out
 
 
 def test_dependency_loop(item_names_for, capsys):
-    test_content = """
-    import pytest
+    test_content = (
+        """
+        import pytest
 
-    @pytest.mark.order(after="test_3")
-    def test_1():
-        pass
+        @pytest.mark.order(after="test_3")
+        def test_1():
+            pass
 
-    @pytest.mark.order(1)
-    def test_2():
-        pass
+        @pytest.mark.order(1)
+        def test_2():
+            pass
 
-    @pytest.mark.order(before="test_1")
-    def test_3():
-        pass
-    """
+        @pytest.mark.order(before="test_1")
+        def test_3():
+            pass
+        """
+    )
     assert item_names_for(test_content) == ["test_2", "test_1", "test_3"]
     out, err = capsys.readouterr()
-    warning = ("cannot execute test relative to others: "
-               "test_dependency_loop.py::test_3")
+    warning = (
+        "cannot execute test relative to others: "
+        "test_dependency_loop.py::test_3"
+    )
     assert warning in out

--- a/tests/test_sparse_ordinals.py
+++ b/tests/test_sparse_ordinals.py
@@ -11,14 +11,16 @@ def sparse_ordering(ignore_settings):
 
 @pytest.fixture(scope="module")
 def first_test():
-    yield """
-import pytest
+    yield (
+        """
+        import pytest
 
-def test_1(): pass
+        def test_1(): pass
 
-@pytest.mark.order("first")
-def test_2(): pass
-    """
+        @pytest.mark.order("first")
+        def test_2(): pass
+        """
+    )
 
 
 def test_first_default(first_test, item_names_for):
@@ -31,17 +33,19 @@ def test_first_sparse(first_test, item_names_for, sparse_ordering):
 
 @pytest.fixture(scope="module")
 def second_test():
-    yield """
-import pytest
+    yield (
+        """
+        import pytest
 
-def test_1(): pass
-def test_2(): pass
-def test_3(): pass
-def test_4(): pass
+        def test_1(): pass
+        def test_2(): pass
+        def test_3(): pass
+        def test_4(): pass
 
-@pytest.mark.order("second")
-def test_5(): pass
-    """
+        @pytest.mark.order("second")
+        def test_5(): pass
+        """
+    )
 
 
 def test_second_default(second_test, item_names_for):
@@ -58,18 +62,20 @@ def test_second_sparse(second_test, item_names_for, sparse_ordering):
 
 @pytest.fixture(scope="module")
 def third_test():
-    yield """
-import pytest
+    yield (
+        """
+        import pytest
 
-def test_1(): pass
-def test_2(): pass
-def test_3(): pass
+        def test_1(): pass
+        def test_2(): pass
+        def test_3(): pass
 
-@pytest.mark.order("third")
-def test_4(): pass
+        @pytest.mark.order("third")
+        def test_4(): pass
 
-def test_5(): pass
-    """
+        def test_5(): pass
+        """
+    )
 
 
 def test_third_default(third_test, item_names_for):
@@ -86,18 +92,20 @@ def test_third_sparse(third_test, item_names_for, sparse_ordering):
 
 @pytest.fixture(scope="module")
 def second_to_last_test():
-    yield """
-import pytest
+    yield (
+        """
+        import pytest
 
-def test_1(): pass
+        def test_1(): pass
 
-@pytest.mark.order("second_to_last")
-def test_2(): pass
+        @pytest.mark.order("second_to_last")
+        def test_2(): pass
 
-def test_3(): pass
-def test_4(): pass
-def test_5(): pass
-    """
+        def test_3(): pass
+        def test_4(): pass
+        def test_5(): pass
+        """
+    )
 
 
 def test_second_to_last_default(second_to_last_test, item_names_for):
@@ -115,14 +123,16 @@ def test_second_to_last_sparse(second_to_last_test, item_names_for,
 
 @pytest.fixture(scope="module")
 def last_test():
-    yield """
-import pytest
+    yield (
+        """
+        import pytest
 
-@pytest.mark.order("last")
-def test_1(): pass
+        @pytest.mark.order("last")
+        def test_1(): pass
 
-def test_2(): pass
-    """
+        def test_2(): pass
+        """
+    )
 
 
 def test_last_default(last_test, item_names_for):
@@ -135,17 +145,19 @@ def test_last_sparse(last_test, item_names_for, sparse_ordering):
 
 @pytest.fixture(scope="module")
 def first_last_test():
-    yield """
-import pytest
+    yield (
+        """
+        import pytest
 
-@pytest.mark.order("last")
-def test_1(): pass
+        @pytest.mark.order("last")
+        def test_1(): pass
 
-@pytest.mark.order("first")
-def test_2(): pass
+        @pytest.mark.order("first")
+        def test_2(): pass
 
-def test_3(): pass
-    """
+        def test_3(): pass
+        """
+    )
 
 
 def test_first_last_default(first_last_test, item_names_for):
@@ -158,22 +170,24 @@ def test_first_last_sparse(first_last_test, item_names_for, sparse_ordering):
 
 @pytest.fixture(scope="module")
 def duplicate_numbers_test():
-    yield """
-import pytest
+    yield (
+        """
+        import pytest
 
-@pytest.mark.order(1)
-def test_1(): pass
+        @pytest.mark.order(1)
+        def test_1(): pass
 
-@pytest.mark.order(1)
-def test_2(): pass
+        @pytest.mark.order(1)
+        def test_2(): pass
 
-def test_3(): pass
+        def test_3(): pass
 
-def test_4(): pass
+        def test_4(): pass
 
-@pytest.mark.order(4)
-def test_5(): pass
-    """
+        @pytest.mark.order(4)
+        def test_5(): pass
+        """
+    )
 
 
 def test_duplicate_numbers_default(duplicate_numbers_test, item_names_for):
@@ -182,8 +196,9 @@ def test_duplicate_numbers_default(duplicate_numbers_test, item_names_for):
     ]
 
 
-def test_duplicate_numbers_sparse(duplicate_numbers_test, item_names_for,
-                                  sparse_ordering):
+def test_duplicate_numbers_sparse(
+    duplicate_numbers_test, item_names_for, sparse_ordering
+):
     assert item_names_for(duplicate_numbers_test) == [
         "test_3", "test_1", "test_2", "test_4", "test_5"
     ]
@@ -191,21 +206,23 @@ def test_duplicate_numbers_sparse(duplicate_numbers_test, item_names_for,
 
 @pytest.fixture(scope="module")
 def end_items_test():
-    yield """
-import pytest
+    yield (
+        """
+        import pytest
 
-@pytest.mark.order(-2)
-def test_1(): pass
+        @pytest.mark.order(-2)
+        def test_1(): pass
 
-@pytest.mark.order(-4)
-def test_2(): pass
+        @pytest.mark.order(-4)
+        def test_2(): pass
 
-def test_3(): pass
+        def test_3(): pass
 
-def test_4(): pass
+        def test_4(): pass
 
-def test_5(): pass
-    """
+        def test_5(): pass
+        """
+    )
 
 
 def test_end_items_default(end_items_test, item_names_for):

--- a/tests/test_xdist_handling.py
+++ b/tests/test_xdist_handling.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from textwrap import dedent
 
 import pytest
 import pytest_order
@@ -7,53 +8,53 @@ import pytest_order
 def test_xdist_ordering(tmpdir):
     testname = str(tmpdir.join("first_test.py"))
     with open(testname, "w") as fi:
-        fi.write(
+        fi.write(dedent(
             """
-import pytest
+            import pytest
 
-val = 1
+            val = 1
 
-@pytest.mark.order("second")
-def test_second_integer():
-    global val
-    assert val == 2
-    val += 1
+            @pytest.mark.order("second")
+            def test_second_integer():
+                global val
+                assert val == 2
+                val += 1
 
-def test_last_integer():
-    assert val == 3
+            def test_last_integer():
+                assert val == 3
 
-@pytest.mark.order("first")
-def test_first_integer():
-    global val
-    assert val == 1
-    val += 1
-"""
-        )
+            @pytest.mark.order("first")
+            def test_first_integer():
+                global val
+                assert val == 1
+                val += 1
+            """
+        ))
 
     testname = str(tmpdir.join("second_test.py"))
     with open(testname, "w") as fi:
-        fi.write(
+        fi.write(dedent(
             """
-import pytest
+            import pytest
 
-val = "frog"
+            val = "frog"
 
-@pytest.mark.order("second")
-def test_second_string():
-    global val
-    assert val == "goat"
-    val = "fish"
+            @pytest.mark.order("second")
+            def test_second_string():
+                global val
+                assert val == "goat"
+                val = "fish"
 
-def test_last_string():
-    assert val == "fish"
+            def test_last_string():
+                assert val == "fish"
 
-@pytest.mark.order("first")
-def test_first_string():
-    global val
-    assert val == "frog"
-    val = "goat"
-"""
-        )
+            @pytest.mark.order("first")
+            def test_first_string():
+                global val
+                assert val == "frog"
+                val = "goat"
+            """
+        ))
     # With `loadfile`, the tests should pass
     args = ["-n3", "--dist=loadfile", str(tmpdir)]
     ret = pytest.main(args, [pytest_order])


### PR DESCRIPTION
This PR applies the [Black code style](https://black.readthedocs.io/en/stable/the_black_code_style.html) formatting to the entire project.

I've applied the Black-style formatting manually, ensuring to not miss anything. As bad as this may sound, I did this mostly because the black formatter was being overzealous in a couple of cases, resulting in less readable files. Because of that I'd, advise against using a CI formatting test with Black, and instead either format the code you're working on yourself (following the Black's formatting style, like I did), or run Black on the file you're currently working on (after you're done with it ofc), reverting any change it does that may make the code less readable. Alternatively, I can try adding some `# fmt: (on|off|skip)` comments to the code, to help in those places where Black formatting would be undesirable - please let me know if you'd prefer that.

Style / Syntax only code changes (zero runtime impact):
- Included `.vscode/settings.json` file, with some basic rulers showing maximum line length and specifying `black` as the formatter. Should have no impact on anyone using a different IDE or code editor, and I can remove this file from the PR if necessary.  It won't do anything, unless you'd open this project in VSCode.
- All project-related imports have been reduced from `pytest_order.<module>` to just `.<module>`.  
- Changed u-strings (`u"...."`) to normal strings, since those were only relevant in Python 2.7

Transparent code changes (the code changed, but everything still works the same way):
- `docs/source/conf.py`: shortened the absolute path insert line
- Various files: imported `textwrap.dedent` to use it in places where a temporary Python file was created by the test. This allowed me to format the multi-line strings nicely, while retaining the exact same written file contents (the excess indent is stripped before the file is written).  

Other code changes:
- `pytest_order/item.py` (see L111 in the new version): Added a missing space to the warning text
- `pytest_order/plugin.py` (`pytest_addoption` function): Added a missing space in to the `order-scope` option description (see L55-56 in the old version)

Tests pass locally, so hopefully everything will work in the CI too.