### PR TITLE
Fixed all the typings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Test plugin",
+            "type": "python",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["-v"]
+        }
+    ]
+}

--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Adam Talsma <adam@talsma.ca>
 Brian Maissy <brian.maissy@gmail.com>
 Jonas Zinn <jonas.s.zinn@gmail.com>
 Andrew Gilbert <andrewg800@gmail.com>
+Bartosz Peszek <bartosz.peszek@gmail.com>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-#
+from typing import List, Dict
+
 # pytest-order documentation build configuration file, created by
 # sphinx-quickstart on Mon Mar 17 18:20:44 2014.
 #
@@ -75,7 +76,7 @@ release = __version__
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns: List[str] = []
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -135,7 +136,7 @@ html_theme = "nature"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path: List[str] = []
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -188,7 +189,7 @@ htmlhelp_basename = "pytest-orderdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
-latex_elements = {
+latex_elements: Dict[str, str] = {
     # The paper size ("letterpaper" or "a4paper").
     # "papersize": "letterpaper",
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,16 +1,19 @@
 [mypy]
-# Ensures correct typing information inside non-typed functions
+; Ensures correct typing information inside non-typed functions
 check_untyped_defs = True
-# Silences errors about missing imports
-# (type-checks correctly when they're not missing tho)
-ignore_missing_imports = True  # needed for VSCode
-# Strict checking for None
+; Strict checking for None
 no_implicit_optional = True
-# Disallow none and partial generics
+; Disallow none and partial generics
 disallow_any_generics = True
-# Point out pointless things
+; Point out pointless things
 warn_redundant_casts = True
 warn_unused_ignores = True
-# Misc
+; Misc
 show_error_codes = True
-show_column_numbers = True  # needed for VSCode
+
+; These are needed for VSCode
+; Silences errors about missing imports
+; (type-checks correctly when they're not missing tho)
+ignore_missing_imports = True
+; Needed to position the underline correctly
+show_column_numbers = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,16 @@
+[mypy]
+# Ensures correct typing information inside non-typed functions
+check_untyped_defs = True
+# Silences errors about missing imports
+# (type-checks correctly when they're not missing tho)
+ignore_missing_imports = True  # needed for VSCode
+# Strict checking for None
+no_implicit_optional = True
+# Disallow none and partial generics
+disallow_any_generics = True
+# Point out pointless things
+warn_redundant_casts = True
+warn_unused_ignores = True
+# Misc
+show_error_codes = True
+show_column_numbers = True  # needed for VSCode

--- a/pytest_order/plugin.py
+++ b/pytest_order/plugin.py
@@ -36,12 +36,16 @@ def pytest_configure(config: Config) -> None:
         # to keep the function as a function and then add it to the class as a
         # pseudo method.  Since the class is purely for structuring and `self`
         # is never referenced, this seems reasonable.
-        OrderingPlugin.pytest_collection_modifyitems = pytest.hookimpl(
-            function=modify_items, tryfirst=True
+        setattr(
+            OrderingPlugin, "pytest_collection_modifyitems", pytest.hookimpl(
+                function=modify_items, tryfirst=True
+            )
         )
     else:
-        OrderingPlugin.pytest_collection_modifyitems = pytest.hookimpl(
-            function=modify_items, trylast=True
+        setattr(
+            OrderingPlugin, "pytest_collection_modifyitems", pytest.hookimpl(
+                function=modify_items, trylast=True
+            )
         )
     config.pluginmanager.register(OrderingPlugin(), "orderingplugin")
 

--- a/pytest_order/sorter.py
+++ b/pytest_order/sorter.py
@@ -2,7 +2,7 @@
 import sys
 from warnings import warn
 from contextlib import suppress
-from typing import Optional, List, Dict, Tuple, OrderedDict, cast
+from typing import Optional, List, Dict, Tuple, cast
 
 from _pytest.config import Config
 from _pytest.mark import Mark
@@ -12,6 +12,20 @@ from .item import (
     Item, ItemList, ItemGroup, filter_marks, move_item, RelativeMark
 )
 from .settings import Settings, Scope
+
+try:
+    from typing import OrderedDict
+except ImportError:
+    # In Python <3.7.2, we need to stub it
+    from collections import OrderedDict as OrderedDict_cls
+    from typing import MutableMapping, TypeVar
+
+    KT = TypeVar("KT")
+    VT = TypeVar("VT")
+
+    class OrderedDict(OrderedDict_cls, MutableMapping[KT, VT]):  # type: ignore
+        pass
+
 
 orders_map = {
     "first": 0,

--- a/pytest_order/sorter.py
+++ b/pytest_order/sorter.py
@@ -145,10 +145,7 @@ class Sorter:
         aliases[name_mark] = item
 
     def handle_order_mark(self, item: Item) -> None:
-        mark = item.item.get_closest_marker("order")
-        if mark is None:
-            # failsafe
-            return
+        mark = cast(Mark, item.item.get_closest_marker("order"))
         order = mark.args[0] if mark.args else mark.kwargs.get("index")
         if order is not None:
             if isinstance(order, int):


### PR DESCRIPTION
This PR fixes and unifies all the typing information this plugin uses.

General notes:

- Added a `launch.json` file, allowing for an easy way to debug the plugin's existing tests. This won't follow the placed breakpoints within each test after they're collected, but is better than nothing.
- Added a `mypy.ini` settings file, with some sensible strictness flags included. Currently, the entire plugin type-checks properly with those, with zero issues found across all source and test files.

Code and code maintenance notes:
- Important: Because of how it's used, the `RelativeMark` class is now a parametrized generic - this means that wherever it's used as the typing, it needs to be parametrized, with either `Item` or `ItemGroup`, denoting which of those two the mark is for. All currently-existing places where it's used as a typing, have had the appropriate type parameter added - but it's also expected to include those in any future code, where more `RelativeMark` typings would be used.
- `item.py` at L69 and L74: The if statement has been moved within the method, to stop MyPy from complaining about `item.order` possibly being `None`
- `plugin.py`: Since MyPy really doesn't like overwriting methods like that, I've changed it into `setattr` usage, which doesn't generate any errors. This has zero runtime impact.
- `sorter.py` at L48: Changed the double `split` usage into single [`rpartition`](https://docs.python.org/3/library/stdtypes.html#str.rpartition) - should be slightly faster, and definitely simpler.
- `sorter.py` at L103, L121 and L265: Added missing `Tuple` type parameters.
- `sorter.py` at L115: Removed `item.order = ` assignment, also changing the return type of that method to `None`. `item.order` was already being assigned to inside `handle_order_mark`, so this has zero runtime impact (actually speeds up the code, previously it was being assigned to two times).
- `sorter.py` at L149: Added a failsafe if statement, that is never supposed to run. Done solely because MyPy correctly detected that `get_closest_marker` can possibly return `None`, even though this method is only ran when that marker is checked for previously, and it exists. I chose this solution over a `cast` mostly for simplicity.
- `sorter.py` at L181: Previously, it was theoretically possible for the method to finish, without hitting a return statement. This change fixes that. Also, explicit `KeyError` suppression has been used instead for try-except, as an explicit definition of it being ignored there.
- `sorter.py` at L200-L202: Rewrote the helper function, to play more nicely with MyPy. The result should be the same.
- `sorter.py` at L282: Used a temporary tuple instead of a list, improves code speed.
- `sorter.py` at L522-L523: Used a cast, to tell MyPy that those will definitely be `int` there (according to the loop right above, where there's a check for `None` beforehand). Couldn't go with an if statement here, like in the failsafe marker case, but this will do the same thing.