### PR TITLE
Remove Python 3.10dev from CI builds

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
         exclude:
           - os: windows-latest
             python-version: pypy3

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ relationship to other tests.
 [pytest-ordering](https://github.com/ftobia/pytest-ordering) that provides
 additional features like ordering relative to other tests.
 
-`pytest-order` works with Python 3.6 - 3.10, with pytest 
+`pytest-order` works with Python 3.6 - 3.9, with pytest 
 versions >= 5.0.0, and runs on Linux, macOS and Windows.
 
 Documentation

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -38,7 +38,7 @@ ordering, all configuration options) that are not available in
 
 Supported Python and pytest versions
 ------------------------------------
-``pytest-order`` supports python 3.6 - 3.10 and pypy3, and is
+``pytest-order`` supports python 3.6 - 3.9 and pypy3, and is
 compatible with pytest 5.0.0 or newer (older versions may also work, but are
 not tested).
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
         'Programming Language :: Python :: 3 :: Only',
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
- fails since the last update of the 3.10dev version in GH actions
- will be re-added after the issues with 3.10 are solved