### PR TITLE
Re-enable Python 3.10-dev in CI builds

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev, pypy3]
         exclude:
           - os: windows-latest
             python-version: pypy3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
   name without the parameter value,
   see [#38](https://github.com/pytest-dev/pytest-order/issues/38)
   
+### Infrastructure
+- re-added Python 3.10 to CI tests (for pytest >= 6.2.4)
+  
 ## [Version 0.11.0](https://pypi.org/project/pytest-order/0.11.0/) (2021-04-11)
 Adds support for multiple relative markers for the same test.
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ relationship to other tests.
 [pytest-ordering](https://github.com/ftobia/pytest-ordering) that provides
 additional features like ordering relative to other tests.
 
-`pytest-order` works with Python 3.6 - 3.9, with pytest 
-versions >= 5.0.0, and runs on Linux, macOS and Windows.
+`pytest-order` works with Python 3.6 - 3.10, with pytest 
+versions >= 5.0.0 for all versions except Python 3.10, and for pytest >=
+6.2.4 for Python 3.10. `pytest-order` runs on Linux, macOS and Windows.
 
 Documentation
 -------------

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -38,9 +38,10 @@ ordering, all configuration options) that are not available in
 
 Supported Python and pytest versions
 ------------------------------------
-``pytest-order`` supports python 3.6 - 3.9 and pypy3, and is
+``pytest-order`` supports python 3.6 - 3.10 and pypy3, and is
 compatible with pytest 5.0.0 or newer (older versions may also work, but are
-not tested).
+not tested) for Python versions up to 3.9, and with pytest >= 6.2.4 for
+Python 3.10.
 
 All supported combinations of Python and pytest versions are tested in
 the CI builds. The plugin shall work under Linux, MacOs and Windows.

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         'Programming Language :: Python :: 3 :: Only',
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    {py36,py37,py38,py39,py310dev,pypy3}-pytest{50,51,52,53,54,60,61,62}
+    {py36,py37,py38,py39,pypy3}-pytest{50,51,52,53,54,60,61,62}
+    {py310dev}-pytest{624}
 [testenv]
 deps =
     pytest50: pytest>=5.0,<5.1
@@ -11,9 +12,10 @@ deps =
     pytest60: pytest>=6.0,<6.1
     pytest61: pytest>=6.1,<6.2
     pytest62: pytest>=6.2,<6.3
+    pytest624: pytest>=6.2.4,<6.3
     pytest-cov<2.10
     pytest{50,51,52,53,54}: pytest-xdist<2.0.0
-    pytest{60,61,62}: pytest-xdist
+    pytest{60,61,62,624}: pytest-xdist
     pytest-dependency>=0.5.1
     pytest-mock
 


### PR DESCRIPTION
- restrict Python 3.10 to pytest >= 3.2.4