### PR TITLE
Fix automark_dependency handling for pytest-dependency main

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", pypy3]
         exclude:
           - os: windows-latest
             python-version: pypy3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixes
 - correctly handle combined class and test order markers,
   see [#45](https://github.com/pytest-dev/pytest-order/issues/45)
+- adapt code to changed type of `automark_dependency` in development branch
+  of `pytest-dependency`,
+  see [#58](https://github.com/pytest-dev/pytest-order/issues/58)
 
 ## [Version 1.0.0](https://pypi.org/project/pytest-order/1.0.0/) (2021-05-30)
 First Python 3 only version.

--- a/README.md
+++ b/README.md
@@ -21,12 +21,33 @@ Documentation
 Apart from this overview, the following information is available:
 - usage documentation for the [latest release](https://pytest-dev.github.io/pytest-order/stable/)
 - usage documentation for the [current main branch](https://pytest-dev.github.io/pytest-order/dev/)
-- all examples shown in the documentation can also be found in the 
+- most examples shown in the documentation can also be found in the 
   [repository](https://github.com/pytest-dev/pytest-order/tree/main/example)
 - the [Release Notes](https://github.com/pytest-dev/pytest-order/blob/main/CHANGELOG.md)
   with a list of changes in the latest versions
 - a [list of open issues](https://github.com/pytest-dev/pytest-order/blob/main/old_issues.md)
   in the original project and their handling in `pytest-order`
+
+Features
+--------
+`pytest-order` provides the following features:
+- ordering of tests [by index](https://pytest-dev.github.io/pytest-order/stable/usage.html#ordering-by-numbers)
+- ordering of tests both from the start and from the end (via negative
+  index)
+- ordering of tests [relative to each other](https://pytest-dev.github.io/pytest-order/stable/usage.html#order-relative-to-other-tests)
+  (via the `before` and `after` marker attributes)
+- session-, module- and class-scope ordering via the
+  [order-scope](https://pytest-dev.github.io/pytest-order/stable/configuration.html#order-scope) option
+- directory scope ordering via the
+  [order-scope-level](https://pytest-dev.github.io/pytest-order/stable/configuration.html#order-scope-level) option
+- hierarchical module and class-level ordering via the 
+  [order-group-scope](https://pytest-dev.github.io/pytest-order/stable/configuration.html#order-group-scope) option
+- ordering tests with `pytest-dependency` markers if using the
+  [order-dependencies](https://pytest-dev.github.io/pytest-order/stable/configuration.html#order-dependencies) option, 
+  more information about `pytest-dependency` compatibility
+  [here](https://pytest-dev.github.io/pytest-order/stable/other_plugins.html#relationship-with-pytest-dependency) 
+- sparse ordering of tests via the 
+  [sparse-ordering](https://pytest-dev.github.io/pytest-order/stable/configuration.html#sparse-ordering) option
 
 Overview
 --------
@@ -69,25 +90,6 @@ yields the output:
     test_foo.py:3: test_foo PASSED
 
     =========================== 2 passed in 0.01 seconds ===========================
-
-Features
---------
-`pytest-order` provides the following features:
-- ordering of tests by index, as shown above
-- ordering of tests both from the start and from the end (via negative
-  index)
-- ordering of tests relative to each other (via the `before` and `after`
-  marker attributes) 
-- session-, module- and class-scope ordering via the ``order-scope`` option
-- directory scope ordering via the ``order-scope-level`` option
-- hierarchical module and class-level ordering via the ``group-order-scope``
-  option
-- ordering tests with `pytest-dependency` markers if using the
-  ``order-dependencies`` option
-- sparse ordering of tests via the ``sparse-ordering`` option
-  
-A usage guide for each feature can be
-found in the [documentation](https://pytest-dev.github.io/pytest-order/dev/).
 
 Contributing
 ------------

--- a/pytest_order/settings.py
+++ b/pytest_order/settings.py
@@ -56,9 +56,10 @@ class Settings:
             self.group_scope = self.scope
         try:
             auto_mark_dep = config.getini("automark_dependency")
+            if isinstance(auto_mark_dep, str):
+                auto_mark_dep = auto_mark_dep.lower() in (
+                    "1", "yes", "y", "true", "t", "on"
+                )
         except ValueError:
             auto_mark_dep = False
-        self.auto_mark_dep = (
-            auto_mark_dep
-            and auto_mark_dep.lower() in ("1", "yes", "y", "true", "t", "on")
-        )
+        self.auto_mark_dep = auto_mark_dep

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     {py36,py37,py38,py39,pypy3}-pytest{50,51,52,53,54,60,61,62}
-    {py310dev}-pytest{624}
+    {py310}-pytest{624}
 [testenv]
 deps =
     pytest50: pytest>=5.0,<5.1


### PR DESCRIPTION

- use Python 3.10 instead of pre-release version in CI
- add some documentation links in README
- fixes #58