### PR TITLE
Handling multiple markers to run tests several times

### DIFF
--- a/pytest_order/plugin.py
+++ b/pytest_order/plugin.py
@@ -5,6 +5,7 @@ import pytest
 from _pytest.config import Config
 from _pytest.config.argparsing import Parser
 from _pytest.main import Session
+from _pytest.mark import Mark
 from _pytest.python import Function
 
 from .sorter import Sorter
@@ -102,6 +103,29 @@ def pytest_addoption(parser: Parser) -> None:
             "if needed."
         ),
     )
+
+def _get_mark_description(mark: Mark):
+    if mark.kwargs:
+        return ", ".join([f"{k}={v}" for k, v in mark.kwargs.items()])
+    elif mark.args:
+        return f"index={mark.args[0]}"
+    return mark
+
+
+def pytest_generate_tests(metafunc):
+    """Convert tests with several order marks to parametrized tests with corresponding order marks."""
+    if getattr(metafunc, "function", False):
+        if getattr(metafunc.function, "pytestmark", False):
+            # Get list of order marks
+            order_marks = [mark for mark in metafunc.function.pytestmark if mark.name == "order"]
+            if len(order_marks) > 1:
+                # Remove all order marks
+                metafunc.function.pytestmark = [mark for mark in metafunc.function.pytestmark if mark.name != "order"]
+                # Prepare arguments for parametrization including "run" parameters and pytest.mark.order decorators
+                args = [pytest.param(_get_mark_description(mark), marks=[mark]) for mark in order_marks]
+                if "order" not in metafunc.fixturenames:
+                    metafunc.fixturenames.append("order")
+                metafunc.parametrize('order', args)
 
 
 class OrderingPlugin:

--- a/tests/test_multiple_ordering.py
+++ b/tests/test_multiple_ordering.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+from textwrap import dedent
+
+import pytest
+
+
+def test_multiple_markers(item_names_for):
+    test_content = (
+        """
+        import pytest
+        
+        @pytest.mark.order(2)
+        def test_1():
+            pass
+
+        @pytest.mark.order(1)
+        @pytest.mark.order(3)
+        def test_2():
+            pass
+        """
+    )
+    assert item_names_for(test_content) == [
+        "test_2[index=1]",
+        "test_1",
+        "test_2[index=3]",
+    ]
+
+
+def test_with_relative_markers(item_names_for):
+    test_content = (
+        """
+        import pytest
+
+        def test_1():
+            pass
+
+        @pytest.mark.order(before="test_1")
+        @pytest.mark.order(2)
+        def test_2():
+            pass
+
+        @pytest.mark.order(1)
+        @pytest.mark.order(before="test_1")
+        def test_3():
+            pass
+
+        @pytest.mark.order(-1)
+        @pytest.mark.order(-3)
+        def test_4():
+            pass
+
+        @pytest.mark.order(-2)
+        @pytest.mark.order(-4)
+        def test_5():
+            pass
+        """
+    )
+    assert item_names_for(test_content) == [
+        "test_3[index=1]",
+        "test_2[index=2]",
+        "test_3[before=test_1]",
+        "test_2[before=test_1]",
+        "test_1",
+        "test_5[index=-4]",
+        "test_4[index=-3]",
+        "test_5[index=-2]",
+        "test_4[index=-1]"
+    ]
+
+
+def test_multiple_markers_with_parametrization(item_names_for):
+    test_content = (
+        """
+        import pytest
+
+        @pytest.mark.order(2)
+        def test_1():
+            pass
+
+        @pytest.mark.parametrize("arg", ["aaaaa", "bbbbb", "ccccc", "ddddd"])
+        @pytest.mark.order(1)
+        @pytest.mark.order(-1)
+        def test_2(arg):
+            pass
+
+        @pytest.mark.order(3)
+        def test_3():
+            pass
+        """
+    )
+    assert item_names_for(test_content) == [
+        'test_2[index=1-aaaaa]',
+        'test_2[index=1-bbbbb]',
+        'test_2[index=1-ccccc]',
+        'test_2[index=1-ddddd]',
+        'test_1',
+        'test_3',
+        'test_2[index=-1-aaaaa]',
+        'test_2[index=-1-bbbbb]',
+        'test_2[index=-1-ccccc]',
+        'test_2[index=-1-ddddd]'
+    ]

--- a/tests/test_multiple_ordering.py
+++ b/tests/test_multiple_ordering.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
-from textwrap import dedent
-
-import pytest
-
 
 def test_multiple_markers(item_names_for):
     test_content = (
         """
         import pytest
-        
+
         @pytest.mark.order(2)
         def test_1():
             pass

--- a/tests/test_relative_ordering.py
+++ b/tests/test_relative_ordering.py
@@ -322,28 +322,6 @@ def test_combined_markers2(item_names_for):
     assert item_names_for(test_content) == ["test_3", "test_2", "test_1"]
 
 
-def test_multiple_markers(item_names_for):
-    test_content = (
-        """
-        import pytest
-
-        def test_1():
-            pass
-
-        @pytest.mark.order(before="test_1")
-        @pytest.mark.order(2)
-        def test_2():
-            pass
-
-        @pytest.mark.order(1)
-        @pytest.mark.order(before="test_1")
-        def test_3():
-            pass
-        """
-    )
-    assert item_names_for(test_content) == ["test_3", "test_2", "test_1"]
-
-
 def test_combined_markers3(item_names_for):
     test_content = (
         """


### PR DESCRIPTION
Long story short, I was answering a [question on StackOverflow](https://stackoverflow.com/questions/75614032/pytest-order-test-a-then-test-b-and-then-test-a-again) about running test several times using multiple `pytest.mark.order` decorators.

I implemented support if multiple order markers using `pytest_generate_tests` hook and had a thought to contribute it here.

Basically it creates parametrization using all `pytest.mark.order` decorators separately, so each parameter can be sorted.

Order mark arguments (`args` and `kwargs`) are passed to parameter called "order". You can find some examples in `test_multiple_ordering.py`.

All tests are passing and it supports parametrization as well (`test_multiple_ordering.py::test_multiple_markers_with_parametrization`)

Please have a look and let me know what you think!
