### PR TITLE
Add pytest 8.0 to CI tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Infrastructure
 - avoid unknown marker warning in tests (see [#101](https://github.com/pytest-dev/pytest-order/issues/101))
+- added pytest 8 to CI tests
 
 ## [Version 1.2.0](https://pypi.org/project/pytest-order/1.2.0/) (2023-11-18)
 Allows using custom markers for ordering.

--- a/old_issues.md
+++ b/old_issues.md
@@ -7,8 +7,8 @@ Tracks the state of all open issues in pytest-ordering for reference.
   manually merged respective [PR](https://github.com/ftobia/pytest-ordering/pull/37)
   by Jonas Zinn :heavy_check_mark:
 - [Custom markers](https://github.com/ftobia/pytest-ordering/issues/10)
-  will not be implemented (see
-  [this issue](https://github.com/ftobia/pytest-ordering/issues/38)) :-1:
+  will not be implemented as proposed (see [this issue](https://github.com/ftobia/pytest-ordering/issues/38)),
+  but `--order-marker-prefix` can be used for this :heavy_check_mark:
 - [Support for ordering testcases](https://github.com/ftobia/pytest-ordering/issues/12)
   unclear question, will ignore :-1:
 - [Test sparse ordinal behavior](https://github.com/ftobia/pytest-ordering/issues/14)
@@ -58,3 +58,5 @@ Tracks the state of all open issues in pytest-ordering for reference.
   obsolete, shall work with respective `order` markers :heavy_check_mark:
 - [license is showing as UNKNOWN in pip show command.](https://github.com/ftobia/pytest-ordering/issues/75)
   fixed by adding the license to `setup.py` :heavy_check_mark:
+- [Ordering a function that has to be executed twice](https://github.com/ftobia/pytest-ordering/issues/80)
+  has been implemented now :heavy_check_mark:

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,21 @@
 [tox]
 envlist =
-    {py37,py38,py39,pypy37,pypy39}-pytest{50,51,52,53,54,60,61,62,70,73}
-    {py310,py311,py312,pypy310}-pytest{624,70,73}
+    {py37,pypy37}-pytest{50,54,60,62,624,70,74}
+    {py38,py39,pypy39}-pytest{50,54,60,62,624,70,74,80}
+    {py310,py311,py312,pypy310}-pytest{624,70,74,80}
 [testenv]
 deps =
     pytest50: pytest>=5.0,<5.1
-    pytest51: pytest>=5.1,<5.2
-    pytest52: pytest>=5.2,<5.3
-    pytest53: pytest>=5.3,<5.4
     pytest54: pytest>=5.4,<6.0
     pytest60: pytest>=6.0,<6.1
-    pytest61: pytest>=6.1,<6.2
     pytest62: pytest>=6.2,<6.3
     pytest624: pytest>=6.2.4,<6.3
     pytest70: pytest>=7.0,<7.1
-    pytest73: pytest>=7.3,<7.4
+    pytest74: pytest>=7.3,<8.0
+    pytest80: pytest>=8.0,<9.0
     pytest-cov<2.10
-    pytest{50,51,52,53,54}: pytest-xdist<2.0.0
-    pytest{60,61,62,624,70,73}: pytest-xdist
+    pytest{50,54}: pytest-xdist<2.0.0
+    pytest{60,62,624,70,74,80}: pytest-xdist
     pytest-dependency>=0.5.1
     pytest-mock
 


### PR DESCRIPTION
- removed a few of the earlier versions from test