### PR TITLE
Handle dependency markers with the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # pytest-order Release Notes
 
+## Fixes
+- handle dependency markers with the same alias name (see [#71](https://github.com/pytest-dev/pytest-order/issues/71))
+
 ## Infrastructure
 - avoid unknown marker warning in tests (see [#101](https://github.com/pytest-dev/pytest-order/issues/101))
 - added pytest 8 to CI tests

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -399,6 +399,61 @@ def test_named_dependency_in_modules(test_path):
     )
 
 
+def test_equally_named_dependency_in_modules(test_path):
+    # regression test for #71
+    test_path.makepyfile(
+        test_ndep1=(
+            """
+            import pytest
+
+            class TestOne:
+
+                @pytest.mark.dependency(name="one", depends=["zero"])
+                def test_one(self):
+                    assert True
+
+                @pytest.mark.dependency(name="two", depends=["one"])
+                def test_two(self):
+                    assert True
+
+                @pytest.mark.dependency(name="three", depends=["two"])
+                def test_three(self):
+                    assert True
+
+                @pytest.mark.dependency(name="zero")
+                def test_zero(self):
+                    assert True
+            """
+        ),
+        test_ndep2=(
+            """
+            import pytest
+
+            class TestTwo:
+
+                @pytest.mark.dependency(name="one", depends=["zero"])
+                def test_one(self):
+                    assert True
+
+                @pytest.mark.dependency(name="two", depends=["one"])
+                def test_two(self):
+                    assert True
+
+                @pytest.mark.dependency(name="three", depends=["two"])
+                def test_three(self):
+                    assert True
+
+                @pytest.mark.dependency(name="zero")
+                def test_zero(self):
+                    assert True
+            """
+        ),
+    )
+
+    result = test_path.runpytest("-v", "--order-dependencies")
+    result.assert_outcomes(passed=8, failed=0, skipped=0)
+
+
 @pytest.mark.skipif(
     pytest.__version__.startswith("3.7."),
     reason="pytest-dependency < 0.5 does not support session scope",


### PR DESCRIPTION
- the same name may be used in different modules
- fixes #71

This came up with tests derived from a base class with dependency markers, so that all derived tests used the same alias name. 