### PR TITLE
Specify rootdir to recursive pytest calls (fixes #110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Fixes
 - handle dependency markers with the same alias name (see [#71](https://github.com/pytest-dev/pytest-order/issues/71))
+- specify rootdir to recursive pytest calls to avoid searching a large directory tree unnecessarily (see [#110](https://github.com/pytest-dev/pytest-order/issues/110))
 
 ## Infrastructure
 - avoid unknown marker warning in tests (see [#101](https://github.com/pytest-dev/pytest-order/issues/101))

--- a/tests/test_xdist_handling.py
+++ b/tests/test_xdist_handling.py
@@ -59,11 +59,11 @@ def test_xdist_ordering(tmpdir):
             )
         )
     # With `loadfile`, the tests should pass
-    args = ["-n3", "--dist=loadfile", str(tmpdir)]
+    args = ["-n3", "--dist=loadfile", f"--rootdir={tmpdir}", str(tmpdir)]
     ret = pytest.main(args, [pytest_order])
     assert ret == 0
 
     # Without `loadfile`, the tests should fail
-    args = ["-n3", str(tmpdir)]
+    args = ["-n3", f"--rootdir={tmpdir}", str(tmpdir)]
     ret = pytest.main(args, [pytest_order])
     assert ret == 1


### PR DESCRIPTION
Following a discussion on the pytest issue https://github.com/pytest-dev/pytest/issues/11781 the source of #110 has become a little clearer: the `rootdir` was set to `/tmp`, being the common ancestor of the temporary test directory and the invocation directory in the CI environment.  This patch specifies the `rootdir` explicitly.