### PR TITLE
Do not use deprecated API in CI

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -27,7 +27,8 @@ jobs:
       id: pip-cache
       run: |
         python -m pip install -U pip
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+        echo "dir=$(pip cache dir)" >> $env:GITHUB_OUTPUT
     - name: pip cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -34,7 +34,8 @@ jobs:
       id: pip-cache
       run: |
         python -m pip install -U pip # to ensure version > 20 to have cache dir
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+        echo "dir=$(pip cache dir)" >> $env:GITHUB_OUTPUT
     - name: pip cache
       uses: actions/cache@v4
       with:


### PR DESCRIPTION
- get rid of CI warning annotations