### PR TITLE
Added option --error-on-failed-ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New features
+- added option `--error-on-failed-ordering` to make tests that cannot be ordered fail
+  (see [#140](https://github.com/pytest-dev/pytest-order/issues/140))
+
 ## Infrastructure
 - added missing documentation examples, structured examples according to documentation structure
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -603,6 +603,49 @@ tests first from the start, then from the end if there are negative numbers,
 and the rest will be in between (e.g. between positive and negative numbers),
 as it is without this option.
 
+``--error-on-failed-ordering``
+------------------------------
+Relative ordering of tests my fail under some circumstances. Mostly this happens if the related marker
+is not found, or if the tests have a cyclic dependency.
+The default behavior in this case is not to order the test in question, issue a warning during test
+collection and execute the test as usual. If you want to make sure that your relative markers work
+without checking all warning messages, you can also make the tests that cannot be ordered fail, so that
+they show up as errored in the report:
+
+.. code:: python
+
+ import pytest
+
+
+ def test_one():
+     assert True
+
+
+ @pytest.mark.order(before="test_three")
+ def test_two():
+     assert True
+
+
+In this example, the test "test_three" on which "test_two" depends, does not exist.
+If you use the option `--error-on-failed-ordering`, "test_two" will now error:
+
+    $ pytest tests -vv --error-on-failed-ordering
+    ============================= test session starts ==============================
+    ...
+    WARNING: cannot execute 'test_two' relative to others: 'test_three'
+
+    test_failed_ordering.py::test_one PASSED
+    test_failed_ordering.py::test_two ERROR
+
+    =================================== ERRORS ====================================
+    __________________________ ERROR at setup of test_two__________________________
+    ...
+    =========================== short test summary info ===========================
+    ERROR test_failed_ordering.py::test_two - Failed: The test could not be ordered
+    ========================= 1 passed, 1 error in 0.75s ==========================
+
+
+
 .. _`pytest-dependency`: https://pypi.org/project/pytest-dependency/
 .. _`dynamic compilation of marked parameters`: https://pytest-dependency.readthedocs.io/en/stable/advanced.html#dynamic-compilation-of-marked-parameters
 .. _`add dependencies at runtime`: https://pytest-dependency.readthedocs.io/en/stable/usage.html#marking-dependencies-at-runtime

--- a/perf_tests/test_dependencies.py
+++ b/perf_tests/test_dependencies.py
@@ -10,24 +10,24 @@ pytest_plugins = ["pytester"]
 @pytest.fixture
 def fixture_path_relative(testdir):
     for i_mod in range(10):
-        test_name = testdir.tmpdir.join("test_dep_perf{}.py".format(i_mod))
+        test_name = testdir.tmpdir.join(f"test_dep_perf{i_mod}.py")
         test_contents = "import pytest\n"
         for i in range(40):
             test_contents += dedent(
-                """
-                @pytest.mark.dependency(depends=["test_{}"])
-                def test_{}():
+                f"""
+                @pytest.mark.dependency(depends=["test_{i + 50}"])
+                def test_{i}():
                     assert True
                 """
-            ).format(i + 50, i)
+            )
         for i in range(60):
             test_contents += dedent(
-                """
+                f"""
                 @pytest.mark.dependency
-                def test_{}():
+                def test_{i + 40}():
                     assert True
                 """
-            ).format(i + 40)
+            )
         test_name.write(test_contents)
     yield testdir
 

--- a/perf_tests/test_ordinal.py
+++ b/perf_tests/test_ordinal.py
@@ -10,16 +10,16 @@ pytest_plugins = ["pytester"]
 @pytest.fixture
 def fixture_path_ordinal(testdir):
     for i_mod in range(10):
-        test_name = testdir.tmpdir.join("test_performance{}.py".format(i_mod))
+        test_name = testdir.tmpdir.join(f"test_performance{i_mod}.py")
         test_contents = "import pytest\n"
         for i in range(100):
             test_contents += dedent(
-                """
-                @pytest.mark.order({})
-                def test_{}():
+                f"""
+                @pytest.mark.order({50 - i})
+                def test_{i}():
                     assert True
                 """
-            ).format(50 - i, i)
+            )
         test_name.write(test_contents)
     yield testdir
 

--- a/perf_tests/test_relative.py
+++ b/perf_tests/test_relative.py
@@ -10,23 +10,23 @@ pytest_plugins = ["pytester"]
 @pytest.fixture
 def fixture_path_relative(testdir):
     for i_mod in range(10):
-        test_name = testdir.tmpdir.join("test_relative_perf{}.py".format(i_mod))
+        test_name = testdir.tmpdir.join(f"test_relative_perf{i_mod}.py")
         test_contents = "import pytest\n"
         for i in range(40):
             test_contents += dedent(
-                """
-                @pytest.mark.order(after="test_{}")
-                def test_{}():
+                f"""
+                @pytest.mark.order(after="test_{i + 50}")
+                def test_{i}():
                     assert True
                 """
-            ).format(i + 50, i)
+            )
         for i in range(60):
             test_contents += dedent(
-                """
-                def test_{}():
+                f"""
+                def test_{i + 40}():
                     assert True
                 """
-            ).format(i + 40)
+            )
         test_name.write(test_contents)
     yield testdir
 

--- a/perf_tests/test_relative_dense.py
+++ b/perf_tests/test_relative_dense.py
@@ -10,23 +10,23 @@ pytest_plugins = ["pytester"]
 @pytest.fixture
 def fixture_path_relative_dense(testdir):
     for i_mod in range(10):
-        test_name = testdir.tmpdir.join("test_relative_dense_perf{}.py".format(i_mod))
+        test_name = testdir.tmpdir.join(f"test_relative_dense_perf{i_mod}.py")
         test_contents = "import pytest\n"
         for i in range(90):
             test_contents += dedent(
-                """
-                @pytest.mark.order(after="test_{}")
-                def test_{}():
+                f"""
+                @pytest.mark.order(after="test_{i + 10}")
+                def test_{i}():
                     assert True
                 """
-            ).format(i + 10, i)
+            )
         for i in range(10):
             test_contents += dedent(
-                """
-                def test_{}():
+                f"""
+                def test_{i + 90}():
                     assert True
                 """
-            ).format(i + 90)
+            )
         test_name.write(test_contents)
     yield testdir
 

--- a/perf_tests/util.py
+++ b/perf_tests/util.py
@@ -12,5 +12,5 @@ class TimedSorter(Sorter):
         start_time = time.time()
         items = super().sort_items()
         self.__class__.elapsed = (time.time() - start_time) / self.nr_marks * 1000
-        print("\nTime per test: {:.3f} ms".format(self.__class__.elapsed))
+        print(f"\nTime per test: {self.__class__.elapsed:.3f} ms")
         return items

--- a/pytest_order/item.py
+++ b/pytest_order/item.py
@@ -102,15 +102,20 @@ class ItemList:
         return sorted_list
 
     def print_unhandled_items(self) -> None:
-        msg = " ".join(
-            [mark.item.node_id for mark in self.rel_marks]
-            + [mark.item.node_id for mark in self.dep_marks]
-        )
-        if msg:
-            sys.stdout.write("\nWARNING: cannot execute test relative to others: ")
-            sys.stdout.write(msg)
+        failed_items = [mark.item for mark in self.rel_marks] + [
+            mark.item for mark in self.dep_marks
+        ]
+        msg = " ".join([item.node_id for item in failed_items])
+        sys.stdout.write("\nWARNING: cannot execute test relative to others: ")
+        sys.stdout.write(msg)
+        if self.settings.error_on_failed_ordering:
             sys.stdout.write(" - ignoring the marker.\n")
-            sys.stdout.flush()
+        else:
+            sys.stdout.write(".\n")
+        sys.stdout.flush()
+        if self.settings.error_on_failed_ordering:
+            for item in failed_items:
+                item.item.fixturenames.insert(0, "fail_after_cannot_order")
 
     def number_of_rel_groups(self) -> int:
         return len(self.rel_marks) + len(self.dep_marks)

--- a/pytest_order/plugin.py
+++ b/pytest_order/plugin.py
@@ -110,6 +110,15 @@ def pytest_addoption(parser: Parser) -> None:
             "are handled like order markers with an index."
         ),
     )
+    group.addoption(
+        "--error-on-failed-ordering",
+        action="store_true",
+        dest="error_on_failed_ordering",
+        help=(
+            "If set, tests with relative markers that could not be ordered "
+            "will error instead of generating only a warning."
+        ),
+    )
 
 
 def _get_mark_description(mark: Mark):
@@ -144,6 +153,11 @@ def pytest_generate_tests(metafunc):
                 if "order" not in metafunc.fixturenames:
                     metafunc.fixturenames.append("order")
                 metafunc.parametrize("order", args)
+
+
+@pytest.fixture
+def fail_after_cannot_order():
+    pytest.fail("The test could not be ordered")
 
 
 class OrderingPlugin:

--- a/pytest_order/settings.py
+++ b/pytest_order/settings.py
@@ -32,15 +32,14 @@ class Settings:
         else:
             if scope is not None:
                 warn(
-                    "Unknown order scope '{}', ignoring it. "
-                    "Valid scopes are 'session', 'module' and 'class'.".format(scope)
+                    f"Unknown order scope '{scope}', ignoring it. "
+                    "Valid scopes are 'session', 'module' and 'class'."
                 )
             self.scope = Scope.SESSION
         scope_level: int = config.getoption("order_scope_level") or 0
         if scope_level != 0 and self.scope != Scope.SESSION:
             warn(
-                "order-scope-level cannot be used together with "
-                "--order-scope={}".format(scope)
+                f"order-scope-level cannot be used together with --order-scope={scope}"
             )
             scope_level = 0
         self.scope_level: int = scope_level
@@ -50,10 +49,8 @@ class Settings:
         else:
             if group_scope is not None:
                 warn(
-                    "Unknown order group scope '{}', ignoring it. "
-                    "Valid scopes are 'session', 'module' and 'class'.".format(
-                        group_scope
-                    )
+                    f"Unknown order group scope '{group_scope}', ignoring it. "
+                    "Valid scopes are 'session', 'module' and 'class'."
                 )
             self.group_scope = self.scope
         if self.group_scope.value > self.scope.value:

--- a/pytest_order/settings.py
+++ b/pytest_order/settings.py
@@ -23,6 +23,9 @@ class Settings:
         self.sparse_ordering: bool = config.getoption("sparse_ordering")
         self.order_dependencies: bool = config.getoption("order_dependencies")
         self.marker_prefix: str = config.getoption("order_marker_prefix")
+        self.error_on_failed_ordering: str = config.getoption(
+            "error_on_failed_ordering"
+        )
         scope: str = config.getoption("order_scope")
         if scope in self.valid_scopes:
             self.scope: Scope = self.valid_scopes[scope]

--- a/pytest_order/sorter.py
+++ b/pytest_order/sorter.py
@@ -162,7 +162,7 @@ class Sorter:
             elif order in orders_map:
                 order = orders_map[order]
             else:
-                warn("Unknown order attribute:'{}'".format(order))
+                warn(f"Unknown order attribute:'{order}'")
                 order = None
         if item.order is None:
             item.order = order
@@ -269,11 +269,15 @@ class Sorter:
                 self.warn_about_unknown_test(item, after_mark)
         return has_relative_marks
 
-    @staticmethod
-    def warn_about_unknown_test(item: Item, rel_mark: str) -> None:
+    def warn_about_unknown_test(self, item: Item, rel_mark: str) -> None:
+        if self.settings.error_on_failed_ordering:
+            item.item.fixturenames.insert(0, "fail_after_cannot_order")
+            ignore_msg = ""
+        else:
+            ignore_msg = " - ignoring the marker"
         sys.stdout.write(
-            "\nWARNING: cannot execute '{}' relative to others: "
-            "'{}' - ignoring the marker.".format(item.item.name, rel_mark)
+            f"\nWARNING: cannot execute '{item.item.name}' relative to others: "
+            f"'{rel_mark}'{ignore_msg}."
         )
 
     def collect_markers(self) -> None:
@@ -303,8 +307,8 @@ class Sorter:
                         )
                 else:
                     sys.stdout.write(
-                        "\nWARNING: Cannot resolve the dependency marker '{}' "
-                        "- ignoring it.".format(name)
+                        f"\nWARNING: Cannot resolve the dependency marker '{name}' "
+                        "- ignoring it."
                     )
 
     @staticmethod

--- a/tests/test_order_scope_level.py
+++ b/tests/test_order_scope_level.py
@@ -28,7 +28,7 @@ def fixture_path(test_path):
         """
     )
     for i in range(3):
-        sub_path = "feature{}".format(i)
+        sub_path = f"feature{i}"
         test_path.mkpydir(sub_path)
         path = test_path.tmpdir.join(sub_path, "test_a.py")
         path.write(test_a_contents)


### PR DESCRIPTION
- makes tests error that cannot be ordered
- closes #140
- also replaced old `format()` by f-strings