### PR TITLE
Pin Python 3.7 builds to ubuntu 22.04

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.11]
+        python-version: [3.8, 3.13]
     env:
       OS: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -14,14 +14,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - python-version: "pypy-3.7"
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - python-version: "pypy-3.9"
             os: ubuntu-latest
           - python-version: "pypy-3.10"
             os: ubuntu-latest
+          - python-version: "3.7"
+            os: ubuntu-22.04
+          - python-version: "3.7"
+            os: windows-latest
     env:
       OS: ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Infrastructure
 * use trusted publisher for release (see https://docs.pypi.org/trusted-publishers/)
+* pin Python 3.7 builds to ubuntu 22.04 (not available in 24.04)
 
 ## [Version 1.3.0](https://pypi.org/project/pytest-order/1.3.0/) (2024-08-22)
 Allows to fail tests that cannot be ordered.


### PR DESCRIPTION
- the newest runner has changed to 24.04, which has no Python 3.7 support